### PR TITLE
chore: Remove dependency on covenant-emulator

### DIFF
--- a/clientcontroller/babylon.go
+++ b/clientcontroller/babylon.go
@@ -473,7 +473,7 @@ func (bc *BabylonController) QueryActiveDelegations(limit uint64) ([]*btcstaking
 	return bc.queryDelegationsWithStatus(btcstakingtypes.BTCDelegationStatus_ACTIVE, limit)
 }
 
-// queryDelegationsWithStatus queries BTC delegations that need a Covenant signature
+// queryDelegationsWithStatus queries BTC delegations
 // with the given status (either pending or unbonding)
 // it is only used when the program is running in Covenant mode
 func (bc *BabylonController) queryDelegationsWithStatus(status btcstakingtypes.BTCDelegationStatus, limit uint64) ([]*btcstakingtypes.BTCDelegation, error) {

--- a/clientcontroller/babylon.go
+++ b/clientcontroller/babylon.go
@@ -361,7 +361,10 @@ func (bc *BabylonController) Close() error {
 	return bc.bbnClient.Stop()
 }
 
-// Currently this is only used for e2e tests, probably does not need to add it into the interface
+/*
+	Implementations for e2e tests only
+*/
+
 func (bc *BabylonController) CreateBTCDelegation(
 	delBabylonPk *secp256k1.PubKey,
 	delBtcPk *bbntypes.BIP340PubKey,
@@ -408,8 +411,6 @@ func (bc *BabylonController) CreateBTCDelegation(
 	return &types.TxResponse{TxHash: res.TxHash}, nil
 }
 
-// Insert BTC block header using rpc client
-// Currently this is only used for e2e tests, probably does not need to add it into the interface
 func (bc *BabylonController) InsertBtcBlockHeaders(headers []bbntypes.BTCHeaderBytes) (*provider.RelayerTxResponse, error) {
 	msg := &btclctypes.MsgInsertHeaders{
 		Signer:  bc.mustGetTxSigner(),
@@ -424,8 +425,6 @@ func (bc *BabylonController) InsertBtcBlockHeaders(headers []bbntypes.BTCHeaderB
 	return res, nil
 }
 
-// QueryFinalityProvider queries finality providers
-// Currently this is only used for e2e tests, probably does not need to add this into the interface
 func (bc *BabylonController) QueryFinalityProviders() ([]*btcstakingtypes.FinalityProvider, error) {
 	var fps []*btcstakingtypes.FinalityProvider
 	pagination := &sdkquery.PageRequest{
@@ -448,7 +447,6 @@ func (bc *BabylonController) QueryFinalityProviders() ([]*btcstakingtypes.Finali
 	return fps, nil
 }
 
-// Currently this is only used for e2e tests, probably does not need to add this into the interface
 func (bc *BabylonController) QueryBtcLightClientTip() (*btclctypes.BTCHeaderInfo, error) {
 	res, err := bc.bbnClient.QueryClient.BTCHeaderChainTip()
 	if err != nil {
@@ -458,7 +456,6 @@ func (bc *BabylonController) QueryBtcLightClientTip() (*btclctypes.BTCHeaderInfo
 	return res.Header, nil
 }
 
-// Currently this is only used for e2e tests, probably does not need to add this into the interface
 func (bc *BabylonController) QueryVotesAtHeight(height uint64) ([]bbntypes.BIP340PubKey, error) {
 	res, err := bc.bbnClient.QueryClient.VotesAtHeight(height)
 	if err != nil {
@@ -489,12 +486,7 @@ func (bc *BabylonController) queryDelegationsWithStatus(status btcstakingtypes.B
 		return nil, fmt.Errorf("failed to query BTC delegations: %v", err)
 	}
 
-	dels := make([]*btcstakingtypes.BTCDelegation, 0, len(res.BtcDelegations))
-	for _, d := range res.BtcDelegations {
-		dels = append(dels, d)
-	}
-
-	return dels, nil
+	return res.BtcDelegations, nil
 }
 
 func (bc *BabylonController) QueryStakingParams() (*types.StakingParams, error) {

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	cosmossdk.io/math v1.2.0
 	github.com/avast/retry-go/v4 v4.5.1
 	github.com/babylonchain/babylon v0.7.2-0.20240121090242-60e5612f9acb
-	github.com/babylonchain/covenant-emulator v0.0.0-20240122065420-24422ab54cb6
 	github.com/babylonchain/rpc-client v0.7.0-rc0.0.20240121104942-d8a42431b1c2
 	github.com/btcsuite/btcd v0.23.5-0.20230711222809-7faa9b266231
 	github.com/btcsuite/btcd/btcec/v2 v2.3.2

--- a/go.sum
+++ b/go.sum
@@ -280,8 +280,6 @@ github.com/aws/aws-sdk-go v1.44.312/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
 github.com/babylonchain/babylon v0.7.2-0.20240121090242-60e5612f9acb h1:WRRhO4JT97Kq/4NrUmE5UzLEPth6ZKkI64hnje9nqvw=
 github.com/babylonchain/babylon v0.7.2-0.20240121090242-60e5612f9acb/go.mod h1:UJMehldQROFooqS5rXMd6avJSjwIsc0jpL+uKoOsTls=
-github.com/babylonchain/covenant-emulator v0.0.0-20240122065420-24422ab54cb6 h1:NMgDiBBuA0xfcS8LTaP2Lpca9j6qWJnMfbQ2u1HYj2k=
-github.com/babylonchain/covenant-emulator v0.0.0-20240122065420-24422ab54cb6/go.mod h1:Rz51BAn7ym3Nf53FZ0R+pJXMj5GPwD0alVqDR+f+Rjw=
 github.com/babylonchain/rpc-client v0.7.0-rc0.0.20240121104942-d8a42431b1c2 h1:FWsneAs2tSact+VKJuwVtX6xjj10OtthA1np4AG2CQ4=
 github.com/babylonchain/rpc-client v0.7.0-rc0.0.20240121104942-d8a42431b1c2/go.mod h1:3WkXcOZX2m0VvM4K6KshfiSQeTz3sSCjVw+NQ6Ayx2U=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=

--- a/itest/e2e_test.go
+++ b/itest/e2e_test.go
@@ -157,7 +157,7 @@ func TestFastSync(t *testing.T) {
 	_ = tm.InsertBTCDelegation(t, []*btcec.PublicKey{fpIns.MustGetBtcPk()}, stakingTime, stakingAmount)
 
 	// check the BTC delegation is pending
-	_ = tm.WaitForNPendingDels(t, 1)
+	dels := tm.WaitForNPendingDels(t, 1)
 
 	// send covenant sigs
 	tm.InsertCovenantSigForDelegation(t, dels[0])

--- a/itest/e2e_test.go
+++ b/itest/e2e_test.go
@@ -180,7 +180,7 @@ func TestFastSync(t *testing.T) {
 	t.Logf("the latest finalized block is at %v", finalizedHeight)
 
 	// check if the fast sync works by checking if the gap is not more than 1
-	currentHeaderRes, err := tm.FPBBNClient.QueryBestBlock()
+	currentHeaderRes, err := tm.BBNClient.QueryBestBlock()
 	currentHeight := currentHeaderRes.Height
 	t.Logf("the current block is at %v", currentHeight)
 	require.NoError(t, err)

--- a/itest/test_manager.go
+++ b/itest/test_manager.go
@@ -397,7 +397,7 @@ func (tm *TestManager) InsertCovenantSigForDelegation(t *testing.T, btcDel *bsty
 
 	stakingInfo, err := btcstaking.BuildStakingInfo(
 		btcDel.BtcPk.MustToBTCPK(),
-		// TODO: Handle multplie providers
+		// TODO: Handle multiple providers
 		[]*btcec.PublicKey{btcDel.FpBtcPkList[0].MustToBTCPK()},
 		params.CovenantPks,
 		params.CovenantQuorum,

--- a/itest/test_manager.go
+++ b/itest/test_manager.go
@@ -405,6 +405,7 @@ func (tm *TestManager) InsertCovenantSigForDelegation(t *testing.T, btcDel *bsty
 		btcutil.Amount(btcDel.TotalSat),
 		simnetParams,
 	)
+	require.NoError(t, err)
 	stakingTxUnbondingPathInfo, err := stakingInfo.UnbondingPathSpendInfo()
 	require.NoError(t, err)
 
@@ -439,6 +440,7 @@ func (tm *TestManager) InsertCovenantSigForDelegation(t *testing.T, btcDel *bsty
 		tm.CovenantPrivKeys[0],
 		valEncKey,
 	)
+	require.NoError(t, err)
 	covenantUnbondingSig1, err := btcstaking.SignTxWithOneScriptSpendInputFromTapLeaf(
 		unbondingMsgTx,
 		stakingInfo.StakingOutput,
@@ -476,6 +478,7 @@ func (tm *TestManager) InsertCovenantSigForDelegation(t *testing.T, btcDel *bsty
 		tm.CovenantPrivKeys[1],
 		valEncKey,
 	)
+	require.NoError(t, err)
 	covenantUnbondingSig2, err := btcstaking.SignTxWithOneScriptSpendInputFromTapLeaf(
 		unbondingMsgTx,
 		stakingInfo.StakingOutput,
@@ -493,7 +496,6 @@ func (tm *TestManager) InsertCovenantSigForDelegation(t *testing.T, btcDel *bsty
 		tm.CovenantPrivKeys[1],
 		valEncKey,
 	)
-	require.NoError(t, err)
 
 	require.NoError(t, err)
 	_, err = tm.BBNClient.SubmitCovenantSigs(

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -213,4 +213,8 @@ require (
 )
 
 // Downgraded to stable version see: https://github.com/cosmos/cosmos-sdk/pull/14952
-replace github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
+replace (
+	// use cosmos fork of keyring
+	github.com/99designs/keyring => github.com/cosmos/keyring v1.2.0
+	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
+)

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -224,8 +224,6 @@ filippo.io/edwards25519 v1.0.0 h1:0wAIcmJUqRdI8IJ/3eGi5/HwXZWPujYXXlkrQogz0Ek=
 filippo.io/edwards25519 v1.0.0/go.mod h1:N1IkdkCkiLB6tki+MYJoSx2JTY9NUlxZE7eHn5EwJns=
 github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4 h1:/vQbFIOMbk2FiG/kXiLl8BRyzTWDw7gX/Hz7Dd5eDMs=
 github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4/go.mod h1:hN7oaIRCjzsZ2dE+yG5k+rsdt3qcwykqK6HVGcKwsw4=
-github.com/99designs/keyring v1.2.1 h1:tYLp1ULvO7i3fI5vE21ReQuj99QFSs7lGm0xWyJo87o=
-github.com/99designs/keyring v1.2.1/go.mod h1:fc+wB5KTk9wQ9sDx0kFXB3A0MaeGHM9AwRStKOQ5vOA=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 h1:L/gRVlceqvL25UVaW/CKtUDjefjrs0SPonmDGUVOYP0=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
@@ -404,6 +402,8 @@ github.com/cosmos/ibc-go/v8 v8.0.0 h1:QKipnr/NGwc+9L7NZipURvmSIu+nw9jOIWTJuDBqOh
 github.com/cosmos/ibc-go/v8 v8.0.0/go.mod h1:C6IiJom0F3cIQCD5fKwVPDrDK9j/xTu563AWuOmXois=
 github.com/cosmos/ics23/go v0.10.0 h1:iXqLLgp2Lp+EdpIuwXTYIQU+AiHj9mOC2X9ab++bZDM=
 github.com/cosmos/ics23/go v0.10.0/go.mod h1:ZfJSmng/TBNTBkFemHHHj5YY7VAU/MBU980F4VU1NG0=
+github.com/cosmos/keyring v1.2.0 h1:8C1lBP9xhImmIabyXW4c3vFjjLiBdGCmfLUfeZlV1Yo=
+github.com/cosmos/keyring v1.2.0/go.mod h1:fc+wB5KTk9wQ9sDx0kFXB3A0MaeGHM9AwRStKOQ5vOA=
 github.com/cosmos/ledger-cosmos-go v0.13.3 h1:7ehuBGuyIytsXbd4MP43mLeoN2LTOEnk5nvue4rK+yM=
 github.com/cosmos/ledger-cosmos-go v0.13.3/go.mod h1:HENcEP+VtahZFw38HZ3+LS3Iv5XV6svsnkk9vdJtLr8=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=

--- a/types/stakingparams.go
+++ b/types/stakingparams.go
@@ -1,0 +1,42 @@
+package types
+
+import (
+	sdkmath "cosmossdk.io/math"
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil"
+)
+
+type StakingParams struct {
+	// K-deep
+	ComfirmationTimeBlocks uint64
+	// W-deep
+	FinalizationTimeoutBlocks uint64
+
+	// Minimum amount of tx fee (quantified in Satoshi) needed for the pre-signed slashing tx
+	MinSlashingTxFeeSat btcutil.Amount
+
+	// Bitcoin public keys of the covenant committee
+	CovenantPks []*btcec.PublicKey
+
+	// Address to which slashing transactions are sent
+	SlashingAddress btcutil.Address
+
+	// Minimum number of signatures needed for the covenant multisignature
+	CovenantQuorum uint32
+
+	// The staked amount to be slashed, expressed as a decimal (e.g., 0.5 for 50%).
+	SlashingRate sdkmath.LegacyDec
+
+	// The minimum time for unbonding transaction timelock in BTC blocks
+	MinUnbondingTime uint32
+}
+
+// MinimumUnbondingTime returns the minimum unbonding time. It is the bigger value from:
+// - MinUnbondingTime
+// - CheckpointFinalizationTimeout
+func (p *StakingParams) MinimumUnbondingTime() uint64 {
+	return sdkmath.Max[uint64](
+		uint64(p.MinUnbondingTime),
+		p.FinalizationTimeoutBlocks,
+	)
+}


### PR DESCRIPTION
This PR fixed #206. The approach is inspired by [btc-staker](https://github.com/babylonchain/btc-staker) which constructs covenant sigs internally in e2e tests instead of using a covenant-emulator instance.