### PR TITLE
fix(doc): Inconsistency of keyringbackend in doc

### DIFF
--- a/docs/eots.md
+++ b/docs/eots.md
@@ -65,10 +65,8 @@ Below are the `eotsd.conf` file contents:
 # Default address to listen for RPC connections
 RpcListener = 127.0.0.1:15813
 
-# Type of keyring to use,
-# supported backends - (os|file|kwallet|pass|test|memory)
-# ref https://docs.cosmos.network/v0.46/run-node/keyring.html#available-backends-for-the-keyring
-KeyringBackend = file
+# Type of keyring to use
+KeyringBackend = test
 
 # Possible database to choose as backend
 Backend = bbolt

--- a/docs/finality-provider.md
+++ b/docs/finality-provider.md
@@ -77,9 +77,7 @@ GRPCAddr = https://127.0.0.1:9090
 # Name of the key in the keyring to use for signing transactions
 Key = <finality-provider-key-name>
 
-# Type of keyring to use,
-# supported backends - (os|file|kwallet|pass|test|memory)
-# ref https://docs.cosmos.network/v0.46/run-node/keyring.html#available-backends-for-the-keyring
+# Type of keyring to use
 KeyringBackend = test
 
 # Directory where keys will be retrieved from and stored


### PR DESCRIPTION
As we have keyring backend of `test` as the default value. This should be consistent with the docs. Also, due to issue #145, `file` keyring backend is not well supported (user needs to type the passphrase prompted from the eotsd's terminal).