### PR TITLE
chore: Fix panicking upon expected error during retrying

### DIFF
--- a/clientcontroller/babylon.go
+++ b/clientcontroller/babylon.go
@@ -214,9 +214,9 @@ func (bc *BabylonController) SubmitFinalitySig(fpPk *btcec.PublicKey, blockHeigh
 		return nil, err
 	}
 	if res == nil {
-		// NOTE: this can happen when encountering ErrDuplicatedFinalitySig
+		// NOTE: this can happen when encountering expected errors
 		// during retrying
-		return &types.TxResponse{}, nil
+		return nil, fmt.Errorf("encountered expected err: %w", Expected(err))
 	}
 
 	return &types.TxResponse{TxHash: res.TxHash, Events: res.Events}, nil
@@ -255,9 +255,9 @@ func (bc *BabylonController) SubmitBatchFinalitySigs(fpPk *btcec.PublicKey, bloc
 		return nil, err
 	}
 	if res == nil {
-		// NOTE: this can happen when encountering ErrDuplicatedFinalitySig
+		// NOTE: this can happen when encountering expected errors
 		// during retrying
-		return &types.TxResponse{}, nil
+		return nil, fmt.Errorf("encountered expected err: %w", Expected(err))
 	}
 
 	return &types.TxResponse{TxHash: res.TxHash, Events: res.Events}, nil

--- a/clientcontroller/babylon.go
+++ b/clientcontroller/babylon.go
@@ -100,18 +100,12 @@ func (bc *BabylonController) reliablySendMsg(msg sdk.Msg, expectedErrs []*sdkErr
 }
 
 func (bc *BabylonController) reliablySendMsgs(msgs []sdk.Msg, expectedErrs []*sdkErr.Error, unrecoverableErrs []*sdkErr.Error) (*provider.RelayerTxResponse, error) {
-	res, err := bc.bbnClient.ReliablySendMsgs(
+	return bc.bbnClient.ReliablySendMsgs(
 		context.Background(),
 		msgs,
 		expectedErrs,
 		unrecoverableErrs,
 	)
-
-	if err != nil {
-		return nil, err
-	}
-
-	return res, nil
 }
 
 // RegisterFinalityProvider registers a finality provider via a MsgCreateFinalityProvider to Babylon

--- a/clientcontroller/babylon.go
+++ b/clientcontroller/babylon.go
@@ -210,7 +210,7 @@ func (bc *BabylonController) SubmitFinalitySig(fpPk *btcec.PublicKey, blockHeigh
 	if res == nil {
 		// NOTE: this can happen when encountering expected errors
 		// during retrying
-		return nil, Expected(fmt.Errorf("expected error"))
+		return nil, Expected(fmt.Errorf("expected error: %w", finalitytypes.ErrDuplicatedFinalitySig))
 	}
 
 	return &types.TxResponse{TxHash: res.TxHash, Events: res.Events}, nil
@@ -251,7 +251,7 @@ func (bc *BabylonController) SubmitBatchFinalitySigs(fpPk *btcec.PublicKey, bloc
 	if res == nil {
 		// NOTE: this can happen when encountering expected errors
 		// during retrying
-		return nil, Expected(fmt.Errorf("expected error"))
+		return nil, Expected(fmt.Errorf("expected error: %w", finalitytypes.ErrDuplicatedFinalitySig))
 	}
 
 	return &types.TxResponse{TxHash: res.TxHash, Events: res.Events}, nil

--- a/clientcontroller/babylon.go
+++ b/clientcontroller/babylon.go
@@ -216,7 +216,7 @@ func (bc *BabylonController) SubmitFinalitySig(fpPk *btcec.PublicKey, blockHeigh
 	if res == nil {
 		// NOTE: this can happen when encountering expected errors
 		// during retrying
-		return nil, fmt.Errorf("encountered expected err: %w", Expected(err))
+		return nil, Expected(fmt.Errorf("expected error"))
 	}
 
 	return &types.TxResponse{TxHash: res.TxHash, Events: res.Events}, nil
@@ -257,7 +257,7 @@ func (bc *BabylonController) SubmitBatchFinalitySigs(fpPk *btcec.PublicKey, bloc
 	if res == nil {
 		// NOTE: this can happen when encountering expected errors
 		// during retrying
-		return nil, fmt.Errorf("encountered expected err: %w", Expected(err))
+		return nil, Expected(fmt.Errorf("expected error"))
 	}
 
 	return &types.TxResponse{TxHash: res.TxHash, Events: res.Events}, nil

--- a/clientcontroller/babylon.go
+++ b/clientcontroller/babylon.go
@@ -97,12 +97,23 @@ func (bc *BabylonController) reliablySendMsg(msg sdk.Msg) (*provider.RelayerTxRe
 }
 
 func (bc *BabylonController) reliablySendMsgs(msgs []sdk.Msg) (*provider.RelayerTxResponse, error) {
-	return bc.bbnClient.ReliablySendMsgs(
+	res, err := bc.bbnClient.ReliablySendMsgs(
 		context.Background(),
 		msgs,
 		expectedErrors,
 		unrecoverableErrors,
 	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if res == nil {
+		// this can happen when the error is expected during retrying
+		return &provider.RelayerTxResponse{}, nil
+	}
+
+	return res, nil
 }
 
 // RegisterFinalityProvider registers a finality provider via a MsgCreateFinalityProvider to Babylon

--- a/clientcontroller/retry_utils.go
+++ b/clientcontroller/retry_utils.go
@@ -13,8 +13,6 @@ import (
 var unrecoverableErrors = []*sdkErr.Error{
 	finalitytypes.ErrBlockNotFound,
 	finalitytypes.ErrInvalidFinalitySig,
-	finalitytypes.ErrHeightTooHigh,
-	finalitytypes.ErrInvalidPubRand,
 	finalitytypes.ErrNoPubRandYet,
 	finalitytypes.ErrPubRandNotFound,
 	finalitytypes.ErrTooFewPubRand,
@@ -24,23 +22,6 @@ var unrecoverableErrors = []*sdkErr.Error{
 // IsUnrecoverable returns true when the error is in the unrecoverableErrors list
 func IsUnrecoverable(err error) bool {
 	for _, e := range unrecoverableErrors {
-		if errors.Is(err, e) {
-			return true
-		}
-	}
-
-	return false
-}
-
-var expectedErrors = []*sdkErr.Error{
-	// if due to some low-level reason (e.g., network), we submit duplicated finality sig,
-	// we should just ignore the error
-	finalitytypes.ErrDuplicatedFinalitySig,
-}
-
-// IsExpected returns true when the error is in the expectedErrors list
-func IsExpected(err error) bool {
-	for _, e := range expectedErrors {
 		if errors.Is(err, e) {
 			return true
 		}

--- a/clientcontroller/retry_utils.go
+++ b/clientcontroller/retry_utils.go
@@ -29,3 +29,17 @@ func IsUnrecoverable(err error) bool {
 
 	return false
 }
+
+type ExpectedError struct {
+	error
+}
+
+// Expected wraps an error in ExpectedError struct
+func Expected(err error) error {
+	return ExpectedError{err}
+}
+
+// IsExpected checks if error is an instance of ExpectedError
+func IsExpected(err error) bool {
+	return errors.Is(err, ExpectedError{})
+}

--- a/clientcontroller/retry_utils.go
+++ b/clientcontroller/retry_utils.go
@@ -34,6 +34,23 @@ type ExpectedError struct {
 	error
 }
 
+func (e ExpectedError) Error() string {
+	if e.error == nil {
+		return "expected error"
+	}
+	return e.error.Error()
+}
+
+func (e ExpectedError) Unwrap() error {
+	return e.error
+}
+
+// Is adds support for errors.Is usage on isExpected
+func (ExpectedError) Is(err error) bool {
+	_, isExpected := err.(ExpectedError)
+	return isExpected
+}
+
 // Expected wraps an error in ExpectedError struct
 func Expected(err error) error {
 	return ExpectedError{err}

--- a/clientcontroller/retry_utils_test.go
+++ b/clientcontroller/retry_utils_test.go
@@ -1,0 +1,16 @@
+package clientcontroller
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/babylonchain/babylon/x/finality/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExpectedErr(t *testing.T) {
+	expectedErr := Expected(types.ErrDuplicatedFinalitySig)
+	require.True(t, IsExpected(expectedErr))
+	wrappedErr := fmt.Errorf("expected: %w", expectedErr)
+	require.True(t, IsExpected(wrappedErr))
+}

--- a/finality-provider/service/fp_instance.go
+++ b/finality-provider/service/fp_instance.go
@@ -513,6 +513,11 @@ func (fp *FinalityProviderInstance) retrySubmitFinalitySignatureUntilBlockFinali
 			if clientcontroller.IsUnrecoverable(err) {
 				return nil, err
 			}
+
+			if clientcontroller.IsExpected(err) {
+				return nil, nil
+			}
+
 			fp.logger.Debug(
 				"failed to submit finality signature to the consumer chain",
 				zap.String("pk", fp.GetBtcPkHex()),

--- a/finality-provider/service/fp_instance.go
+++ b/finality-provider/service/fp_instance.go
@@ -137,7 +137,7 @@ func (fp *FinalityProviderInstance) bootstrap() (uint64, error) {
 
 	if fp.checkLagging(latestBlock) {
 		_, err := fp.tryFastSync(latestBlock)
-		if err != nil {
+		if err != nil && !clientcontroller.IsExpected(err) {
 			return 0, err
 		}
 	}

--- a/finality-provider/service/fp_instance.go
+++ b/finality-provider/service/fp_instance.go
@@ -510,13 +510,6 @@ func (fp *FinalityProviderInstance) retrySubmitFinalitySignatureUntilBlockFinali
 		// error will be returned if max retries have been reached
 		res, err := fp.SubmitFinalitySignature(targetBlock)
 		if err != nil {
-			if clientcontroller.IsUnrecoverable(err) {
-				return nil, err
-			}
-
-			if clientcontroller.IsExpected(err) {
-				return nil, nil
-			}
 
 			fp.logger.Debug(
 				"failed to submit finality signature to the consumer chain",
@@ -525,6 +518,14 @@ func (fp *FinalityProviderInstance) retrySubmitFinalitySignatureUntilBlockFinali
 				zap.Uint64("target_block_height", targetBlock.Height),
 				zap.Error(err),
 			)
+
+			if clientcontroller.IsUnrecoverable(err) {
+				return nil, err
+			}
+
+			if clientcontroller.IsExpected(err) {
+				return nil, nil
+			}
 
 			failedCycles += 1
 			if failedCycles > uint32(fp.cfg.MaxSubmissionRetries) {

--- a/itest/e2e_test.go
+++ b/itest/e2e_test.go
@@ -191,3 +191,65 @@ func TestFastSync(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, currentHeight < finalizedHeight+uint64(n))
 }
+
+// TestFastSync_DuplicateVotes covers a special case when the finality signature
+// has inconsistent view of last voted height with the Babylon node and during
+// fast-sync it submits a batch of finality sigs, one of which is rejected due
+// to duplicate error
+// this test covers this case by starting 3 finality providers, 2 of which
+// are stopped after gaining voting power to simulate the case where no blocks
+// are finalized. Then we let one of the finality providers "forget" the last
+// voted height and restart all the finality providers, expecting it them to
+// catch up and finalize new blocks
+func TestFastSync_DuplicateVotes(t *testing.T) {
+	tm, fpInsList := StartManagerWithFinalityProvider(t, 3)
+	defer tm.Stop(t)
+
+	fpIns1 := fpInsList[0]
+	fpIns2 := fpInsList[1]
+	fpIns3 := fpInsList[2]
+
+	// check the public randomness is committed
+	tm.WaitForFpPubRandCommitted(t, fpIns1)
+	tm.WaitForFpPubRandCommitted(t, fpIns2)
+	tm.WaitForFpPubRandCommitted(t, fpIns3)
+
+	// send 3 BTC delegations to empower the three finality providers
+	_ = tm.InsertBTCDelegation(t, []*btcec.PublicKey{fpIns1.MustGetBtcPk()}, stakingTime, stakingAmount)
+	_ = tm.InsertBTCDelegation(t, []*btcec.PublicKey{fpIns2.MustGetBtcPk()}, stakingTime, stakingAmount)
+	_ = tm.InsertBTCDelegation(t, []*btcec.PublicKey{fpIns3.MustGetBtcPk()}, stakingTime, stakingAmount)
+
+	// check the BTC delegations are pending
+	dels := tm.WaitForNPendingDels(t, 3)
+
+	// send covenant sigs to each delegation
+	tm.InsertCovenantSigForDelegation(t, dels[0])
+	tm.InsertCovenantSigForDelegation(t, dels[1])
+	tm.InsertCovenantSigForDelegation(t, dels[2])
+
+	// check the BTC delegations are active
+	_ = tm.WaitForNActiveDels(t, 3)
+
+	// stop 2 of the finality providers so that no blocks will be finalized
+	err := fpIns2.Stop()
+	require.NoError(t, err)
+	err = fpIns3.Stop()
+	require.NoError(t, err)
+
+	// make sure fp1 has cast a finality vote
+	// and then make it "forget" the last voted height
+	lastVotedHeight := tm.WaitForFpVoteCast(t, fpIns1)
+	fpIns1.MustUpdateStateAfterFinalitySigSubmission(lastVotedHeight - 1)
+
+	// stop fp1, restarts all the fps after 3 blocks for them to catch up
+	// and expect a block will be finalized
+	n := 3
+	tm.FpConfig.FastSyncGap = uint64(n)
+	tm.StopAndRestartFpAfterNBlocks(t, n, fpIns1)
+	err = fpIns2.Start()
+	require.NoError(t, err)
+	err = fpIns3.Start()
+	require.NoError(t, err)
+	finalizedBlocks := tm.WaitForNFinalizedBlocks(t, 1)
+	require.GreaterOrEqual(t, finalizedBlocks[0].Height, lastVotedHeight)
+}


### PR DESCRIPTION
This PR fixed #220. The bug is due to `nil` response will be returned if the error during retrying is expected.