### PR TITLE
fix: Only clean up blocks buffer up to the fast-synced height

### DIFF
--- a/finality-provider/service/chain_poller.go
+++ b/finality-provider/service/chain_poller.go
@@ -270,11 +270,14 @@ func (cp *ChainPoller) SetNextHeight(height uint64) {
 
 func (cp *ChainPoller) SetNextHeightAndClearBuffer(height uint64) {
 	cp.SetNextHeight(height)
-	cp.clearChanBuffer()
+	cp.clearChanBufferUpToHeight(height)
 }
 
-func (cp *ChainPoller) clearChanBuffer() {
+func (cp *ChainPoller) clearChanBufferUpToHeight(upToHeight uint64) {
 	for len(cp.blockInfoChan) > 0 {
-		<-cp.blockInfoChan
+		block := <-cp.blockInfoChan
+		if block.Height+1 >= upToHeight {
+			break
+		}
 	}
 }


### PR DESCRIPTION
In the following scenario:

1. Fast sync starts
2. A new block is retrieved by the poller
3. Fast sync ends

Step 2, adds the new block to the poller blocks channel (which is not known to the fast sync process). However, at step 3, the fast sync process cleans up the block cache, leading to the new block getting lost. 