### PR TITLE
fix: Query best block causing flaky voting power result

### DIFF
--- a/clientcontroller/babylon.go
+++ b/clientcontroller/babylon.go
@@ -336,6 +336,16 @@ func (bc *BabylonController) QueryActivatedHeight() (uint64, error) {
 }
 
 func (bc *BabylonController) QueryBestBlock() (*types.BlockInfo, error) {
+	blocks, err := bc.queryLatestBlocks(nil, 1, finalitytypes.QueriedBlockStatus_ANY, true)
+	if err != nil || len(blocks) != 1 {
+		// try query comet block if the index block query is not available
+		return bc.queryCometBestBlock()
+	}
+
+	return blocks[0], nil
+}
+
+func (bc *BabylonController) queryCometBestBlock() (*types.BlockInfo, error) {
 	ctx, cancel := getContextWithCancel(bc.cfg.Timeout)
 	// this will return 20 items at max in the descending order (highest first)
 	chainInfo, err := bc.bbnClient.RPCClient.BlockchainInfo(ctx, 0, 0)


### PR DESCRIPTION
This PR fixed #223. This bug also affects fast-sync in the sense that it polls the best Comet block as the target block to catch up. Due to the laziness of CometBFT, by the time of polling, the voting power table might not be updated. Therefore, the voting power could be zero and the finality provider might set this block height as `LastProcessHeight` and will never vote for this block.

This PR changed the `QueryBestBlock` by first using the query from the finality module. If there's no indexed block in the finality module, it will fallback to using the query from the CometBFT