### PR TITLE
fix(poller): Next height should not be set with a lower value

### DIFF
--- a/finality-provider/service/chain_poller.go
+++ b/finality-provider/service/chain_poller.go
@@ -26,18 +26,27 @@ const (
 	maxFailedCycles = 20
 )
 
+type skipHeightRequest struct {
+	height uint64
+	resp   chan *skipHeightResponse
+}
+
+type skipHeightResponse struct {
+	err error
+}
+
 type ChainPoller struct {
 	startOnce sync.Once
 	stopOnce  sync.Once
 	wg        sync.WaitGroup
-	mu        sync.Mutex
 	quit      chan struct{}
 
-	cc            clientcontroller.ClientController
-	cfg           *cfg.ChainPollerConfig
-	blockInfoChan chan *types.BlockInfo
-	nextHeight    uint64
-	logger        *zap.Logger
+	cc             clientcontroller.ClientController
+	cfg            *cfg.ChainPollerConfig
+	blockInfoChan  chan *types.BlockInfo
+	skipHeightChan chan *skipHeightRequest
+	nextHeight     uint64
+	logger         *zap.Logger
 }
 
 func NewChainPoller(
@@ -46,11 +55,12 @@ func NewChainPoller(
 	cc clientcontroller.ClientController,
 ) *ChainPoller {
 	return &ChainPoller{
-		logger:        logger,
-		cfg:           cfg,
-		cc:            cc,
-		blockInfoChan: make(chan *types.BlockInfo, cfg.BufferSize),
-		quit:          make(chan struct{}),
+		logger:         logger,
+		cfg:            cfg,
+		cc:             cc,
+		blockInfoChan:  make(chan *types.BlockInfo, cfg.BufferSize),
+		skipHeightChan: make(chan *skipHeightRequest, 1),
+		quit:           make(chan struct{}),
 	}
 }
 
@@ -184,8 +194,8 @@ func (cp *ChainPoller) waitForActivation() {
 		if err != nil {
 			cp.logger.Debug("failed to query the consumer chain for the activated height", zap.Error(err))
 		} else {
-			if cp.GetNextHeight() < activatedHeight {
-				cp.SetNextHeight(activatedHeight)
+			if cp.nextHeight < activatedHeight {
+				cp.nextHeight = activatedHeight
 			}
 			return
 		}
@@ -210,7 +220,7 @@ func (cp *ChainPoller) pollChain() {
 	for {
 		// TODO: Handlig of request cancellation, as otherwise shutdown will be blocked
 		// until request is finished
-		blockToRetrieve := cp.GetNextHeight()
+		blockToRetrieve := cp.nextHeight
 		block, err := cp.blockWithRetry(blockToRetrieve)
 		if err != nil {
 			failedCycles++
@@ -223,7 +233,7 @@ func (cp *ChainPoller) pollChain() {
 		} else {
 			// no error and we got the header we wanted to get, bump the state and push
 			// notification about data
-			cp.SetNextHeight(blockToRetrieve + 1)
+			cp.nextHeight = blockToRetrieve + 1
 			failedCycles = 0
 
 			cp.logger.Info("the poller retrieved the block from the consumer chain",
@@ -242,37 +252,45 @@ func (cp *ChainPoller) pollChain() {
 		select {
 		case <-time.After(cp.cfg.PollInterval):
 
+		case req := <-cp.skipHeightChan:
+			// no need to skip heights if the target height is not higher
+			// than the next height to retrieve
+			targetHeight := req.height
+			if targetHeight <= cp.nextHeight {
+				resp := &skipHeightResponse{
+					err: fmt.Errorf(
+						"the target height %d is not higher than the next height %d to retrieve",
+						targetHeight, cp.nextHeight)}
+				req.resp <- resp
+				continue
+			}
+
+			// drain blocks that can be skipped from blockInfoChan
+			cp.clearChanBufferUpToHeight(targetHeight)
+
+			// set the next height to the skip height
+			cp.nextHeight = targetHeight
+
+			cp.logger.Debug("the poller has skipped height(s)",
+				zap.Uint64("next_height", req.height))
+
+			req.resp <- &skipHeightResponse{}
+
 		case <-cp.quit:
 			return
 		}
 	}
 }
 
-func (cp *ChainPoller) GetNextHeight() uint64 {
-	cp.mu.Lock()
-	defer cp.mu.Unlock()
-	return cp.getNextHeight()
+func (cp *ChainPoller) SkipToHeight(height uint64) error {
+	respChan := make(chan *skipHeightResponse, 1)
+	cp.skipHeightChan <- &skipHeightRequest{height: height, resp: respChan}
+	resp := <-respChan
+	return resp.err
 }
 
-func (cp *ChainPoller) getNextHeight() uint64 {
+func (cp *ChainPoller) NextHeight() uint64 {
 	return cp.nextHeight
-}
-
-func (cp *ChainPoller) setNextHeight(height uint64) {
-	cp.nextHeight = height
-}
-
-func (cp *ChainPoller) SetNextHeight(height uint64) {
-	cp.mu.Lock()
-	defer cp.mu.Unlock()
-	if cp.nextHeight < height {
-		cp.setNextHeight(height)
-	}
-}
-
-func (cp *ChainPoller) SetNextHeightAndClearBuffer(height uint64) {
-	cp.SetNextHeight(height)
-	cp.clearChanBufferUpToHeight(height)
 }
 
 func (cp *ChainPoller) clearChanBufferUpToHeight(upToHeight uint64) {

--- a/finality-provider/service/chain_poller.go
+++ b/finality-provider/service/chain_poller.go
@@ -261,7 +261,9 @@ func (cp *ChainPoller) getNextHeight() uint64 {
 func (cp *ChainPoller) setNextHeight(height uint64) {
 	cp.mu.Lock()
 	defer cp.mu.Unlock()
-	cp.nextHeight = height
+	if cp.nextHeight < height {
+		cp.nextHeight = height
+	}
 }
 
 func (cp *ChainPoller) SetNextHeight(height uint64) {

--- a/finality-provider/service/chain_poller.go
+++ b/finality-provider/service/chain_poller.go
@@ -249,25 +249,25 @@ func (cp *ChainPoller) pollChain() {
 }
 
 func (cp *ChainPoller) GetNextHeight() uint64 {
+	cp.mu.Lock()
+	defer cp.mu.Unlock()
 	return cp.getNextHeight()
 }
 
 func (cp *ChainPoller) getNextHeight() uint64 {
-	cp.mu.Lock()
-	defer cp.mu.Unlock()
 	return cp.nextHeight
 }
 
 func (cp *ChainPoller) setNextHeight(height uint64) {
-	cp.mu.Lock()
-	defer cp.mu.Unlock()
-	if cp.nextHeight < height {
-		cp.nextHeight = height
-	}
+	cp.nextHeight = height
 }
 
 func (cp *ChainPoller) SetNextHeight(height uint64) {
-	cp.setNextHeight(height)
+	cp.mu.Lock()
+	defer cp.mu.Unlock()
+	if cp.nextHeight < height {
+		cp.setNextHeight(height)
+	}
 }
 
 func (cp *ChainPoller) SetNextHeightAndClearBuffer(height uint64) {

--- a/finality-provider/service/chain_poller_test.go
+++ b/finality-provider/service/chain_poller_test.go
@@ -1,0 +1,65 @@
+package service_test
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	fpcfg "github.com/babylonchain/finality-provider/finality-provider/config"
+	"github.com/babylonchain/finality-provider/finality-provider/service"
+	"github.com/babylonchain/finality-provider/testutil"
+	"github.com/babylonchain/finality-provider/testutil/mocks"
+	"github.com/babylonchain/finality-provider/types"
+)
+
+func FuzzChainPoller_Start(f *testing.F) {
+	testutil.AddRandomSeedsToFuzzer(f, 10)
+	f.Fuzz(func(t *testing.T, seed int64) {
+		r := rand.New(rand.NewSource(seed))
+
+		currentHeight := uint64(r.Int63n(100) + 1)
+		startHeight := currentHeight + 1
+		ranHeights := uint64(r.Int63n(10) + 1)
+		endHeight := startHeight + ranHeights
+
+		ctl := gomock.NewController(t)
+		mockClientController := mocks.NewMockClientController(ctl)
+		mockClientController.EXPECT().Close().Return(nil).AnyTimes()
+		mockClientController.EXPECT().QueryActivatedHeight().Return(uint64(1), nil).AnyTimes()
+
+		currentBlockRes := &types.BlockInfo{
+			Height: currentHeight,
+		}
+		mockClientController.EXPECT().QueryBestBlock().Return(currentBlockRes, nil).AnyTimes()
+
+		for i := startHeight; i <= endHeight; i++ {
+			resBlock := &types.BlockInfo{
+				Height: i,
+			}
+			mockClientController.EXPECT().QueryBlock(i).Return(resBlock, nil).AnyTimes()
+		}
+
+		pollerCfg := fpcfg.DefaultChainPollerConfig()
+		pollerCfg.PollInterval = 10 * time.Millisecond
+		poller := service.NewChainPoller(zap.NewNop(), &pollerCfg, mockClientController)
+		err := poller.Start(startHeight)
+		require.NoError(t, err)
+		defer func() {
+			err := poller.Stop()
+			require.NoError(t, err)
+		}()
+
+		for i := startHeight; i <= endHeight; i++ {
+			select {
+			case info := <-poller.GetBlockInfoChan():
+				require.Equal(t, i, info.Height)
+			case <-time.After(10 * time.Second):
+				t.Fatalf("Failed to get block info")
+			}
+		}
+	})
+}

--- a/finality-provider/service/chain_poller_test.go
+++ b/finality-provider/service/chain_poller_test.go
@@ -74,7 +74,7 @@ func FuzzChainPoller_SkipHeight(f *testing.F) {
 
 		currentHeight := uint64(r.Int63n(100) + 1)
 		startHeight := currentHeight + 1
-		endHeight := startHeight + uint64(r.Int63n(10)+1)
+		endHeight := startHeight + uint64(r.Int63n(10)+2)
 		skipHeight := endHeight + uint64(r.Int63n(10)+1)
 
 		ctl := gomock.NewController(t)
@@ -97,11 +97,17 @@ func FuzzChainPoller_SkipHeight(f *testing.F) {
 		pollerCfg := fpcfg.DefaultChainPollerConfig()
 		pollerCfg.PollInterval = 1 * time.Second
 		poller := service.NewChainPoller(zap.NewNop(), &pollerCfg, mockClientController)
-		err := poller.Start(startHeight)
+		// should expect error if the poller is not started
+		err := poller.SkipToHeight(skipHeight)
+		require.Error(t, err)
+		err = poller.Start(startHeight)
 		require.NoError(t, err)
 		defer func() {
 			err := poller.Stop()
 			require.NoError(t, err)
+			// should expect error if the poller is stopped
+			err = poller.SkipToHeight(skipHeight)
+			require.Error(t, err)
 		}()
 
 		var wg sync.WaitGroup

--- a/finality-provider/service/chain_poller_test.go
+++ b/finality-provider/service/chain_poller_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/babylonchain/finality-provider/types"
 )
 
+// FuzzChainPoller_Start tests the poller polling blocks
+// in sequence
 func FuzzChainPoller_Start(f *testing.F) {
 	testutil.AddRandomSeedsToFuzzer(f, 10)
 	f.Fuzz(func(t *testing.T, seed int64) {
@@ -64,6 +66,7 @@ func FuzzChainPoller_Start(f *testing.F) {
 	})
 }
 
+// FuzzChainPoller_SkipHeight tests the functionality of SkipHeight
 func FuzzChainPoller_SkipHeight(f *testing.F) {
 	testutil.AddRandomSeedsToFuzzer(f, 10)
 	f.Fuzz(func(t *testing.T, seed int64) {
@@ -105,8 +108,12 @@ func FuzzChainPoller_SkipHeight(f *testing.F) {
 		wg.Add(1)
 		go func() {
 			wg.Done()
-			err = poller.SkipToHeight(currentHeight - 1)
+			// insert a skipToHeight request with height lower than the next
+			// height to retrieve, expecting an error
+			err = poller.SkipToHeight(poller.NextHeight() - 1)
 			require.Error(t, err)
+			// insert a skipToHeight request with a height higher than the
+			// next height to retrieve
 			err = poller.SkipToHeight(skipHeight)
 			require.NoError(t, err)
 		}()

--- a/finality-provider/service/chain_poller_test.go
+++ b/finality-provider/service/chain_poller_test.go
@@ -2,6 +2,7 @@ package service_test
 
 import (
 	"math/rand"
+	"sync"
 	"testing"
 	"time"
 
@@ -23,8 +24,7 @@ func FuzzChainPoller_Start(f *testing.F) {
 
 		currentHeight := uint64(r.Int63n(100) + 1)
 		startHeight := currentHeight + 1
-		ranHeights := uint64(r.Int63n(10) + 1)
-		endHeight := startHeight + ranHeights
+		endHeight := startHeight + uint64(r.Int63n(10)+1)
 
 		ctl := gomock.NewController(t)
 		mockClientController := mocks.NewMockClientController(ctl)
@@ -61,5 +61,75 @@ func FuzzChainPoller_Start(f *testing.F) {
 				t.Fatalf("Failed to get block info")
 			}
 		}
+	})
+}
+
+func FuzzChainPoller_SkipHeight(f *testing.F) {
+	testutil.AddRandomSeedsToFuzzer(f, 10)
+	f.Fuzz(func(t *testing.T, seed int64) {
+		r := rand.New(rand.NewSource(seed))
+
+		currentHeight := uint64(r.Int63n(100) + 1)
+		startHeight := currentHeight + 1
+		endHeight := startHeight + uint64(r.Int63n(10)+1)
+		skipHeight := endHeight + uint64(r.Int63n(10)+1)
+
+		ctl := gomock.NewController(t)
+		mockClientController := mocks.NewMockClientController(ctl)
+		mockClientController.EXPECT().Close().Return(nil).AnyTimes()
+		mockClientController.EXPECT().QueryActivatedHeight().Return(uint64(1), nil).AnyTimes()
+
+		currentBlockRes := &types.BlockInfo{
+			Height: currentHeight,
+		}
+		mockClientController.EXPECT().QueryBestBlock().Return(currentBlockRes, nil).AnyTimes()
+
+		for i := startHeight; i <= skipHeight; i++ {
+			resBlock := &types.BlockInfo{
+				Height: i,
+			}
+			mockClientController.EXPECT().QueryBlock(i).Return(resBlock, nil).AnyTimes()
+		}
+
+		pollerCfg := fpcfg.DefaultChainPollerConfig()
+		pollerCfg.PollInterval = 1 * time.Second
+		poller := service.NewChainPoller(zap.NewNop(), &pollerCfg, mockClientController)
+		err := poller.Start(startHeight)
+		require.NoError(t, err)
+		defer func() {
+			err := poller.Stop()
+			require.NoError(t, err)
+		}()
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			wg.Done()
+			err = poller.SkipToHeight(currentHeight - 1)
+			require.Error(t, err)
+			err = poller.SkipToHeight(skipHeight)
+			require.NoError(t, err)
+		}()
+
+		skipped := false
+		for i := startHeight; i <= endHeight; i++ {
+			if skipped {
+				break
+			}
+			select {
+			case info := <-poller.GetBlockInfoChan():
+				if info.Height == skipHeight {
+					skipped = true
+				} else {
+					require.Equal(t, i, info.Height)
+				}
+			case <-time.After(10 * time.Second):
+				t.Fatalf("Failed to get block info")
+			}
+		}
+
+		wg.Wait()
+
+		require.Equal(t, skipHeight+1, poller.NextHeight())
 	})
 }

--- a/finality-provider/service/fp_instance.go
+++ b/finality-provider/service/fp_instance.go
@@ -254,7 +254,13 @@ func (fp *FinalityProviderInstance) finalitySigSubmissionLoop() {
 				)
 
 				// set the poller to fetch blocks that have not been processed
-				fp.poller.SetNextHeightAndClearBuffer(fp.GetLastProcessedHeight() + 1)
+				err := fp.poller.SkipToHeight(fp.GetLastProcessedHeight() + 1)
+				if err != nil {
+					fp.logger.Debug(
+						"failed to skip heights from the poller",
+						zap.Error(err),
+					)
+				}
 			}
 		case <-fp.quit:
 			fp.logger.Info("the finality signature submission loop is closing")

--- a/finality-provider/service/fp_instance.go
+++ b/finality-provider/service/fp_instance.go
@@ -253,7 +253,8 @@ func (fp *FinalityProviderInstance) finalitySigSubmissionLoop() {
 					zap.Uint64("last_processed_height", res.LastProcessedHeight),
 				)
 
-				// set the poller to fetch blocks that have not been processed
+				// inform the poller to skip to the next block of the last
+				// processed one
 				err := fp.poller.SkipToHeight(fp.GetLastProcessedHeight() + 1)
 				if err != nil {
 					fp.logger.Debug(


### PR DESCRIPTION
This PR potentially fixed #234. We need to ensure that after fast sync, the poller is still up-to-date. This PR ensures that the next height of the poller should not be set with a lower value.