### PR TITLE
Add kubernetes ready dockerfile for finality provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ export PATH=$HOME/go/bin:$PATH
 echo 'export PATH=$HOME/go/bin:$PATH' >> ~/.profile
 ```
 
+### Running in Docker
+
+The Dockerfile provided [here](./Dockerfile) can be used for developement of Finality Provider whereas a modifed version of the same Dockerfile, which is [this one](./docs/fp.Dockerfile)(exports with `eotsd`, `fpd`, `fpcli` preinstalled) can be used by the users to run a FP container locally or in Kubernetes. Users can paralley run 3 containers of this image  for all the three tools and run their commands inside them respectively.
+
 ## 3. Setting up a finality provider
 
 ### 3.1. Setting up a Babylon Full Node

--- a/docs/fp.Dockerfile
+++ b/docs/fp.Dockerfile
@@ -1,0 +1,63 @@
+####################
+### Build Binaries #
+####################
+
+FROM golang:1.21.1 AS build-env
+
+# Version to build. Default is the Git HEAD.
+ARG VERSION="HEAD"
+
+# Use muslc for static libs
+ARG BUILD_TAGS="muslc"
+
+RUN apt-get update && \
+  apt-get --no-install-recommends --yes install \
+  git-core \
+  wget \
+  bzip2 \
+  jq \
+  vim \
+  ca-certificates \
+  build-essential \
+  pkg-config \
+  cmake \
+  gcc
+
+
+# Cosmwasm - download correct libwasmvm version
+# fp binaries are dependent on this package to run
+RUN git clone --branch v0.1.0 https://github.com/babylonchain/finality-provider.git && \
+  cd finality-provider && \
+  go mod download && \
+  WASMVM_VERSION=$(go list -m github.com/CosmWasm/wasmvm | cut -d ' ' -f 2) && \
+  wget https://github.com/CosmWasm/wasmvm/releases/download/$WASMVM_VERSION/libwasmvm_muslc.$(uname -m).a \
+  -O /lib/libwasmvm_muslc.a && \
+  # verify checksum
+  wget https://github.com/CosmWasm/wasmvm/releases/download/$WASMVM_VERSION/checksums.txt -O /tmp/checksums.txt && \
+  sha256sum /lib/libwasmvm_muslc.a | grep $(cat /tmp/checksums.txt | grep libwasmvm_muslc.$(uname -m) | cut -d ' ' -f 1)
+
+RUN cd finality-provider/ && \
+  CGO_LDFLAGS="$CGO_LDFLAGS -lstdc++ -lm -lsodium" \
+  CGO_ENABLED=1 \
+  BUILD_TAGS=$BUILD_TAGS \
+  LINK_STATICALLY=true && \
+  make build
+
+
+# ###########################
+# ### Finality Provider Run #
+# ###########################
+
+FROM debian:bookworm-slim AS run-env
+
+RUN addgroup --gid  1138 --system finality-provider && \
+  adduser --uid  1138 finality-provider --ingroup finality-provider
+
+# Copy the necessary binaryies from previous steps
+COPY --from=build-env go/finality-provider/build/eotsd /bin/eotsd
+COPY --from=build-env go/finality-provider/build/fpd /bin/fpd
+COPY --from=build-env go/finality-provider/build/fpcli /bin/fpcli
+
+WORKDIR /home/finality-provider
+RUN chown -R finality-provider /home/finality-provider
+USER finality-provider


### PR DESCRIPTION
This PR adds a Dockerfile for Finality Provider that supports all the three tools inside it such as: eotsd, fpd, fpdcli. This is specifically for users not for developers. Whereas users can use this to run a local instance of any of these 3 and use this image in kubernetes also.

- This is more user friendly rather than developer friendly.
- More secure as it uses debian all the way.
- More lightweight as the final stage has only binaries nothing else.
- The user doesn't need the to clone the whole repo with all branches locally, the dockerfile will clone selected release branch which will take less time than the other one to clone.
- It's ready to be used in k8s right away
- It has a mention in the readme, if this gets merged then I will mention in the official docs page ago, so that it will be easy to find