### PR TITLE
fix: Fixes panic in eotsd init

### DIFF
--- a/eotsmanager/cmd/eotsd/init.go
+++ b/eotsmanager/cmd/eotsd/init.go
@@ -57,7 +57,7 @@ func initHome(c *cli.Context) error {
 	}
 
 	defaultConfig := eotscfg.DefaultConfig()
-	fileParser := flags.NewParser(&defaultConfig, flags.Default)
+	fileParser := flags.NewParser(defaultConfig, flags.Default)
 
 	return flags.NewIniParser(fileParser).WriteFile(eotscfg.ConfigFile(homePath), flags.IniIncludeComments|flags.IniIncludeDefaults)
 }


### PR DESCRIPTION
Fixes - https://github.com/babylonchain/finality-provider/issues/266

On building binary from latest commit on dev and `eotsd init`, I am getting this panic 

```
panic: provided data is not a pointer to struct

goroutine 1 [running]:
github.com/jessevdk/go-flags.(*Group).scanType(0x14000134aa0, 0x140005d7520)
	/Users/gusin/go/pkg/mod/github.com/jessevdk/go-flags@v1.5.0/group.go:403 +0x1cc
github.com/jessevdk/go-flags.(*Command).AddGroup(0x140004a1680, {0x10351109f, 0x13}, {0x0, 0x0}, {0x10381ab20, 0x140001fe978})
	/Users/gusin/go/pkg/mod/github.com/jessevdk/go-flags@v1.5.0/command.go:89 +0xe4
github.com/jessevdk/go-flags.NewParser({0x10381ab20, 0x140001fe978}, 0x16)
	/Users/gusin/go/pkg/mod/github.com/jessevdk/go-flags@v1.5.0/parser.go:160 +0x184
main.initHome(0x140004b0dc0)
	/Users/gusin/Github/finality-provider/eotsmanager/cmd/eotsd/init.go:60 +0x1d0
github.com/urfave/cli.HandleAction({0x10384c680?, 0x103a62c80?}, 0x4?)
	/Users/gusin/go/pkg/mod/github.com/urfave/cli@v1.22.14/app.go:524 +0x58
github.com/urfave/cli.Command.Run({{0x1034fbb28, 0x4}, {0x0, 0x0}, {0x0, 0x0, 0x0}, {0x10352c129, 0x24}, {0x0, ...}, ...}, ...)
	/Users/gusin/go/pkg/mod/github.com/urfave/cli@v1.22.14/command.go:175 +0x534
github.com/urfave/cli.(*App).Run(0x140002e8380, {0x1400003c040, 0x2, 0x2})
	/Users/gusin/go/pkg/mod/github.com/urfave/cli@v1.22.14/app.go:277 +0x7f8
main.main()
	/Users/gusin/Github/finality-provider/eotsmanager/cmd/eotsd/main.go:20 +0x1a0
```

On some debugging, found this is due to some typo in config struct