### PR TITLE
feat: eotsd keys add

### DIFF
--- a/docs/eots.md
+++ b/docs/eots.md
@@ -89,3 +89,40 @@ network segment to enhance security. This helps isolate the key management
 functionality and reduces the potential attack surface. You can edit the
 `EOTSManagerAddress` in the configuration file of the finality provider to reference
 the address of the machine where `eotsd` is running.
+
+## 4. Create BTC key
+
+The binary `eotsd` has the option to add a new key to the keyring for
+later usage with BTC key signing. For add a new key run `eotsd keys add`
+command.
+
+This command has several flag options:
+
+- `--home` specifies the home directory of the eots config in which
+the new key will be created.
+- `--key-name` mandatory flag and identifies the name of the key to be generated.
+- `--passphrase` specifies the password used to encrypt the key, if such a
+passphrase is required.
+- `--hd-path` the hd derivation path of the private key.
+- `--keyring-backend` specifies the keyring options, any of `[file, os, kwallet, test, pass, memory]`
+are available, by default `test` is used.
+- `--recover` define that the user needs to provide a seed phrase to recover
+the existing key instead of randomly creating
+
+```shell
+eotsd keys add --home /path/to/eotsd/home/ --key-name my-key-name --keyring-backend file --recover
+
+> Enter your mnemonic
+...
+
+Enter keyring passphrase (attempt 1/3):
+...
+
+2024-04-24T18:00:16.989742Z     info    successfully created an EOTS key        {"key name": "my-key-name", "pk": "7573929fff4a7f777ceeeda7d4ea53eb501b4bd06bf66354e18310d8623b5ebd"}
+New key for the BTC chain is created (mnemonic should be kept in a safe place for recovery):
+{
+  "name": "my-key-name",
+  "pub_key_hex": "7573929fff4a7f777ceeeda7d4ea53eb501b4bd06bf66354e18310d8623b5ebd",
+  "mnemonic": "bad mnemonic private tilt wish bulb miss plate achieve manage feel word safe dash vanish little miss hockey connect tail certain spread urban series"
+}
+```

--- a/docs/eots.md
+++ b/docs/eots.md
@@ -59,42 +59,12 @@ For different operating systems, those are:
 - **Linux** `~/.Eotsd`
 - **Windows** `C:\Users\<username>\AppData\Local\Eotsd`
 
-## 3. Starting the EOTS Daemon
-
-You can start the EOTS daemon using the following command:
-
-```bash
-eotsd start --home /path/to/eotsd/home
-```
-
-If the `--home` flag is not specified, then the default home location will be used.
-
-This will start the EOTS rpc server at the address specified in `eotsd.conf` under
-the `RpcListener` field, which is by default set to `127.0.0.1:12582`. You can change
-this value in the configuration file or override this value and specify a custom
-address using the `--rpc-listener` flag.
-
-```bash
-eotsd start
-
-2024-02-08T17:59:11.467212Z	info	RPC server listening	{"address": "127.0.0.1:12582"}
-2024-02-08T17:59:11.467660Z	info	EOTS Manager Daemon is fully active!
-```
-
-All the available cli options can be viewed using the `--help` flag. These options
-can also be set in the configuration file.
-
-**Note**: It is recommended to run the `eotsd` daemon on a separate machine or
-network segment to enhance security. This helps isolate the key management
-functionality and reduces the potential attack surface. You can edit the
-`EOTSManagerAddress` in the configuration file of the finality provider to reference
-the address of the machine where `eotsd` is running.
-
-## 4. Create EOTS Keys
+## 3. Create EOTS Keys
 
 The binary `eotsd` has the option to add a new key to the keyring for
-later usage with signing EOTS and Schnorr signatures. To add a new key,
-run `eotsd keys add`.
+later usage with signing EOTS and Schnorr signatures. Keep in mind
+that new keys can be created on demand by the GRPC call from `fpd`.
+But, if you would like to add a new EOTS keys manually, run `eotsd keys add`.
 
 This command has several flag options:
 
@@ -137,3 +107,34 @@ bad mnemonic private tilt wish bulb miss plate achieve manage feel word safe das
 ```
 
 You will be prompt to provide the mnemonic on key creation.
+
+## 4. Starting the EOTS Daemon
+
+You can start the EOTS daemon using the following command:
+
+```bash
+eotsd start --home /path/to/eotsd/home
+```
+
+If the `--home` flag is not specified, then the default home location will be used.
+
+This will start the EOTS rpc server at the address specified in `eotsd.conf` under
+the `RpcListener` field, which is by default set to `127.0.0.1:12582`. You can change
+this value in the configuration file or override this value and specify a custom
+address using the `--rpc-listener` flag.
+
+```bash
+eotsd start
+
+2024-02-08T17:59:11.467212Z	info	RPC server listening	{"address": "127.0.0.1:12582"}
+2024-02-08T17:59:11.467660Z	info	EOTS Manager Daemon is fully active!
+```
+
+All the available cli options can be viewed using the `--help` flag. These options
+can also be set in the configuration file.
+
+**Note**: It is recommended to run the `eotsd` daemon on a separate machine or
+network segment to enhance security. This helps isolate the key management
+functionality and reduces the potential attack surface. You can edit the
+`EOTSManagerAddress` in the configuration file of the finality provider to reference
+the address of the machine where `eotsd` is running.

--- a/docs/eots.md
+++ b/docs/eots.md
@@ -90,30 +90,27 @@ functionality and reduces the potential attack surface. You can edit the
 `EOTSManagerAddress` in the configuration file of the finality provider to reference
 the address of the machine where `eotsd` is running.
 
-## 4. Create BTC key
+## 4. Create EOTS Keys
 
 The binary `eotsd` has the option to add a new key to the keyring for
-later usage with BTC key signing. For add a new key run `eotsd keys add`
-command.
+later usage with signing EOTS and Schnorr signatures. To add a new key,
+run `eotsd keys add`.
 
 This command has several flag options:
 
-- `--home` specifies the home directory of the eots config in which
-the new key will be created.
+- `--home` specifies the home directory of the `eotsd` in which
+the new key will be stored.
 - `--key-name` mandatory flag and identifies the name of the key to be generated.
 - `--passphrase` specifies the password used to encrypt the key, if such a
 passphrase is required.
 - `--hd-path` the hd derivation path of the private key.
-- `--keyring-backend` specifies the keyring options, any of `[file, os, kwallet, test, pass, memory]`
+- `--keyring-backend` specifies the keyring backend, any of `[file, os, kwallet, test, pass, memory]`
 are available, by default `test` is used.
-- `--recover` define that the user needs to provide a seed phrase to recover
-the existing key instead of randomly creating
+- `--recover` indicates whether the user wants to provide a seed phrase to recover
+the existing key instead of randomly creating.
 
 ```shell
-eotsd keys add --home /path/to/eotsd/home/ --key-name my-key-name --keyring-backend file --recover
-
-> Enter your mnemonic
-...
+eotsd keys add --home /path/to/eotsd/home/ --key-name my-key-name --keyring-backend file
 
 Enter keyring passphrase (attempt 1/3):
 ...

--- a/docs/eots.md
+++ b/docs/eots.md
@@ -123,3 +123,17 @@ New key for the BTC chain is created (mnemonic should be kept in a safe place fo
   "mnemonic": "bad mnemonic private tilt wish bulb miss plate achieve manage feel word safe dash vanish little miss hockey connect tail certain spread urban series"
 }
 ```
+
+> Store the mnemonic in a safe place. With the mnemonic only it is possible to
+recover the generated keys by using the `--recover` flag.
+
+To recover the keys from a mnemonic, run:
+
+```shell
+eotsd keys add --home /path/to/eotsd/home/ --key-name my-key-name --keyring-backend file --recover
+
+> Enter your mnemonic
+bad mnemonic private tilt wish bulb miss plate achieve manage feel word safe dash vanish little miss hockey connect tail certain spread urban series
+```
+
+You will be prompt to provide the mnemonic on key creation.

--- a/eotsmanager/cmd/eotsd/daemon/flags.go
+++ b/eotsmanager/cmd/eotsd/daemon/flags.go
@@ -1,7 +1,20 @@
 package daemon
 
+import "github.com/cosmos/cosmos-sdk/crypto/keyring"
+
 const (
 	homeFlag        = "home"
 	forceFlag       = "force"
 	rpcListenerFlag = "rpc-listener"
+
+	// flags for keys
+	keyNameFlag        = "key-name"
+	passphraseFlag     = "passphrase"
+	hdPathFlag         = "hd-path"
+	keyringBackendFlag = "keyring-backend"
+	recoverFlag        = "recover"
+
+	defaultKeyringBackend = keyring.BackendTest
+	defaultHdPath         = ""
+	defaultPassphrase     = ""
 )

--- a/eotsmanager/cmd/eotsd/daemon/flags.go
+++ b/eotsmanager/cmd/eotsd/daemon/flags.go
@@ -1,4 +1,4 @@
-package main
+package daemon
 
 const (
 	homeFlag        = "home"

--- a/eotsmanager/cmd/eotsd/daemon/init.go
+++ b/eotsmanager/cmd/eotsd/daemon/init.go
@@ -1,4 +1,4 @@
-package main
+package daemon
 
 import (
 	"fmt"
@@ -11,7 +11,7 @@ import (
 	"github.com/babylonchain/finality-provider/util"
 )
 
-var initCommand = cli.Command{
+var InitCommand = cli.Command{
 	Name:  "init",
 	Usage: "Initialize the eotsd home directory.",
 	Flags: []cli.Flag{

--- a/eotsmanager/cmd/eotsd/daemon/init.go
+++ b/eotsmanager/cmd/eotsd/daemon/init.go
@@ -57,6 +57,7 @@ func initHome(c *cli.Context) error {
 	}
 
 	defaultConfig := eotscfg.DefaultConfig()
+	defaultConfig.DatabaseConfig.DBPath = dataDir
 	fileParser := flags.NewParser(defaultConfig, flags.Default)
 
 	return flags.NewIniParser(fileParser).WriteFile(eotscfg.ConfigFile(homePath), flags.IniIncludeComments|flags.IniIncludeDefaults)

--- a/eotsmanager/cmd/eotsd/daemon/keys.go
+++ b/eotsmanager/cmd/eotsd/daemon/keys.go
@@ -100,7 +100,7 @@ func addKey(ctx *cli.Context) error {
 		return fmt.Errorf("failed to create db backend: %w", err)
 	}
 
-	eotsManager, err := eotsmanager.NewLocalEOTSManager(homePath, cfg, dbBackend, logger)
+	eotsManager, err := eotsmanager.NewLocalEOTSManager(homePath, cfg.KeyringBackend, dbBackend, logger)
 	if err != nil {
 		return fmt.Errorf("failed to create EOTS manager: %w", err)
 	}

--- a/eotsmanager/cmd/eotsd/daemon/keys.go
+++ b/eotsmanager/cmd/eotsd/daemon/keys.go
@@ -37,7 +37,10 @@ var KeysCommands = []cli.Command{
 
 var AddKeyCmd = cli.Command{
 	Name:  "add",
-	Usage: "Add a key to the eots BTC keyring. Note that this will change the config file in place.",
+	Usage: "Add a key to the EOTS manager keyring.",
+	Description: `Add a new key to EOTS manager keyring,
+	 Note that this will change the config file in place for
+	 update the keyring-backend type.`,
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  homeFlag,
@@ -60,12 +63,13 @@ var AddKeyCmd = cli.Command{
 		},
 		cli.StringFlag{
 			Name:  keyringBackendFlag,
-			Usage: "Select keyring's backend",
+			Usage: "The backend of the keyring",
 			Value: defaultKeyringBackend,
 		},
 		cli.BoolFlag{
-			Name:  recoverFlag,
-			Usage: "Provide seed phrase to recover existing key instead of creating",
+			Name: recoverFlag,
+			Usage: `Will need to provider a seed phrase to recover
+	the existing key instead of creating`,
 		},
 	},
 	Action: addKey,

--- a/eotsmanager/cmd/eotsd/daemon/keys.go
+++ b/eotsmanager/cmd/eotsd/daemon/keys.go
@@ -68,7 +68,7 @@ var AddKeyCmd = cli.Command{
 		},
 		cli.BoolFlag{
 			Name: recoverFlag,
-			Usage: `Will need to provider a seed phrase to recover
+			Usage: `Will need to provide a seed phrase to recover
 	the existing key instead of creating`,
 		},
 	},

--- a/eotsmanager/cmd/eotsd/daemon/keys.go
+++ b/eotsmanager/cmd/eotsd/daemon/keys.go
@@ -49,6 +49,7 @@ var AddKeyCmd = cli.Command{
 		},
 		cli.StringFlag{
 			Name:     keyNameFlag,
+			Usage:    "The name of the key to be created",
 			Required: true,
 		},
 		cli.StringFlag{

--- a/eotsmanager/cmd/eotsd/daemon/keys.go
+++ b/eotsmanager/cmd/eotsd/daemon/keys.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client/input"
 	"github.com/cosmos/go-bip39"
-	"github.com/jessevdk/go-flags"
 	"github.com/urfave/cli"
 
 	bbntypes "github.com/babylonchain/babylon/types"
@@ -38,9 +37,6 @@ var KeysCommands = []cli.Command{
 var AddKeyCmd = cli.Command{
 	Name:  "add",
 	Usage: "Add a key to the EOTS manager keyring.",
-	Description: `Add a new key to EOTS manager keyring,
-	 Note that this will change the config file in place for
-	 update the keyring-backend type.`,
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  homeFlag,
@@ -121,10 +117,7 @@ func addKey(ctx *cli.Context) error {
 			Mnemonic:  mnemonic,
 		},
 	)
-
-	// updates the keyring backend if set
-	fileParser := flags.NewParser(cfg, flags.Default)
-	return flags.NewIniParser(fileParser).WriteFile(config.ConfigFile(homePath), flags.IniIncludeComments|flags.IniIncludeDefaults)
+	return nil
 }
 
 // createKey checks if recover flag is set to create a key from mnemonic or if not set, randomly creates it.

--- a/eotsmanager/cmd/eotsd/daemon/keys.go
+++ b/eotsmanager/cmd/eotsd/daemon/keys.go
@@ -86,10 +86,6 @@ func addKey(ctx *cli.Context) error {
 		return fmt.Errorf("failed to load config at %s: %w", homePath, err)
 	}
 
-	if len(keyringBackend) > 0 { // on creation of key it reads the keyring backend from config.
-		cfg.KeyringBackend = keyringBackend
-	}
-
 	logger, err := log.NewRootLoggerWithFile(config.LogFile(homePath), cfg.LogLevel)
 	if err != nil {
 		return fmt.Errorf("failed to load the logger")
@@ -100,7 +96,7 @@ func addKey(ctx *cli.Context) error {
 		return fmt.Errorf("failed to create db backend: %w", err)
 	}
 
-	eotsManager, err := eotsmanager.NewLocalEOTSManager(homePath, cfg.KeyringBackend, dbBackend, logger)
+	eotsManager, err := eotsmanager.NewLocalEOTSManager(homePath, keyringBackend, dbBackend, logger)
 	if err != nil {
 		return fmt.Errorf("failed to create EOTS manager: %w", err)
 	}

--- a/eotsmanager/cmd/eotsd/daemon/keys.go
+++ b/eotsmanager/cmd/eotsd/daemon/keys.go
@@ -1,0 +1,172 @@
+package daemon
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/cosmos/cosmos-sdk/client/input"
+	"github.com/cosmos/go-bip39"
+	"github.com/jessevdk/go-flags"
+	"github.com/urfave/cli"
+
+	bbntypes "github.com/babylonchain/babylon/types"
+	"github.com/babylonchain/finality-provider/eotsmanager"
+	"github.com/babylonchain/finality-provider/eotsmanager/config"
+	"github.com/babylonchain/finality-provider/log"
+)
+
+type KeyOutput struct {
+	Name      string `json:"name" yaml:"name"`
+	PubKeyHex string `json:"pub_key_hex" yaml:"pub_key_hex"`
+	Mnemonic  string `json:"mnemonic,omitempty" yaml:"mnemonic"`
+}
+
+var KeysCommands = []cli.Command{
+	{
+		Name:     "keys",
+		Usage:    "Command sets of managing keys for interacting with BTC eots keys.",
+		Category: "Key management",
+		Subcommands: []cli.Command{
+			AddKeyCmd,
+		},
+	},
+}
+
+var AddKeyCmd = cli.Command{
+	Name:  "add",
+	Usage: "Add a key to the eots BTC keyring. Note that this will change the config file in place.",
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  homeFlag,
+			Usage: "Path to the keyring directory",
+			Value: config.DefaultEOTSDir,
+		},
+		cli.StringFlag{
+			Name:     keyNameFlag,
+			Required: true,
+		},
+		cli.StringFlag{
+			Name:  passphraseFlag,
+			Usage: "The pass phrase used to encrypt the keys",
+			Value: defaultPassphrase,
+		},
+		cli.StringFlag{
+			Name:  hdPathFlag,
+			Usage: "The hd path used to derive the private key",
+			Value: defaultHdPath,
+		},
+		cli.StringFlag{
+			Name:  keyringBackendFlag,
+			Usage: "Select keyring's backend",
+			Value: defaultKeyringBackend,
+		},
+		cli.BoolFlag{
+			Name:  recoverFlag,
+			Usage: "Provide seed phrase to recover existing key instead of creating",
+		},
+	},
+	Action: addKey,
+}
+
+func addKey(ctx *cli.Context) error {
+	keyName := ctx.String(keyNameFlag)
+	keyringBackend := ctx.String(keyringBackendFlag)
+
+	homePath, err := getHomeFlag(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to load home flag: %w", err)
+	}
+
+	cfg, err := config.LoadConfig(homePath)
+	if err != nil {
+		return fmt.Errorf("failed to load config at %s: %w", homePath, err)
+	}
+
+	if len(keyringBackend) > 0 { // on creation of key it reads the keyring backend from config.
+		cfg.KeyringBackend = keyringBackend
+	}
+
+	logger, err := log.NewRootLoggerWithFile(config.LogFile(homePath), cfg.LogLevel)
+	if err != nil {
+		return fmt.Errorf("failed to load the logger")
+	}
+
+	dbBackend, err := cfg.DatabaseConfig.GetDbBackend()
+	if err != nil {
+		return fmt.Errorf("failed to create db backend: %w", err)
+	}
+
+	eotsManager, err := eotsmanager.NewLocalEOTSManager(homePath, cfg, dbBackend, logger)
+	if err != nil {
+		return fmt.Errorf("failed to create EOTS manager: %w", err)
+	}
+
+	eotsPk, mnemonic, err := createKey(ctx, eotsManager, keyName)
+	if err != nil {
+		return fmt.Errorf("failed to create key: %w", err)
+	}
+
+	printRespJSON(
+		KeyOutput{
+			Name:      keyName,
+			PubKeyHex: eotsPk.MarshalHex(),
+			Mnemonic:  mnemonic,
+		},
+	)
+
+	// updates the keyring backend if set
+	fileParser := flags.NewParser(cfg, flags.Default)
+	return flags.NewIniParser(fileParser).WriteFile(config.ConfigFile(homePath), flags.IniIncludeComments|flags.IniIncludeDefaults)
+}
+
+// createKey checks if recover flag is set to create a key from mnemonic or if not set, randomly creates it.
+func createKey(
+	ctx *cli.Context,
+	eotsManager *eotsmanager.LocalEOTSManager,
+	keyName string,
+) (eotsPk *bbntypes.BIP340PubKey, mnemonic string, err error) {
+	passphrase := ctx.String(passphraseFlag)
+	hdPath := ctx.String(hdPathFlag)
+
+	mnemonic, err = getMnemonic(ctx)
+	if err != nil {
+		return nil, "", err
+	}
+
+	eotsPk, err = eotsManager.CreateKeyWithMnemonic(keyName, passphrase, hdPath, mnemonic)
+	if err != nil {
+		return nil, "", err
+	}
+	return eotsPk, mnemonic, nil
+}
+
+func getMnemonic(ctx *cli.Context) (string, error) {
+	if ctx.Bool(recoverFlag) {
+		reader := bufio.NewReader(os.Stdin)
+		mnemonic, err := input.GetString("Enter your mnemonic", reader)
+		if err != nil {
+			return "", fmt.Errorf("failed to read mnemonic from stdin: %w", err)
+		}
+		if !bip39.IsMnemonicValid(mnemonic) {
+			return "", errors.New("invalid mnemonic")
+		}
+
+		return mnemonic, nil
+	}
+
+	return eotsmanager.NewMnemonic()
+}
+
+func printRespJSON(resp interface{}) {
+	jsonBytes, err := json.MarshalIndent(resp, "", "    ")
+	if err != nil {
+		fmt.Println("unable to decode response: ", err)
+		return
+	}
+
+	fmt.Printf("New key for the BTC chain is created "+
+		"(mnemonic should be kept in a safe place for recovery):\n%s\n", jsonBytes)
+}

--- a/eotsmanager/cmd/eotsd/daemon/start.go
+++ b/eotsmanager/cmd/eotsd/daemon/start.go
@@ -1,4 +1,4 @@
-package main
+package daemon
 
 import (
 	"fmt"
@@ -15,7 +15,7 @@ import (
 	"github.com/babylonchain/finality-provider/util"
 )
 
-var startCommand = cli.Command{
+var StartCommand = cli.Command{
 	Name:        "start",
 	Usage:       "Start the Extractable One Time Signature Daemon.",
 	Description: "Start the Extractable One Time Signature Daemon.",

--- a/eotsmanager/cmd/eotsd/daemon/start.go
+++ b/eotsmanager/cmd/eotsd/daemon/start.go
@@ -63,7 +63,7 @@ func startFn(ctx *cli.Context) error {
 		return fmt.Errorf("failed to create db backend: %w", err)
 	}
 
-	eotsManager, err := eotsmanager.NewLocalEOTSManager(homePath, cfg, dbBackend, logger)
+	eotsManager, err := eotsmanager.NewLocalEOTSManager(homePath, cfg.KeyringBackend, dbBackend, logger)
 	if err != nil {
 		return fmt.Errorf("failed to create EOTS manager: %w", err)
 	}

--- a/eotsmanager/cmd/eotsd/daemon/start.go
+++ b/eotsmanager/cmd/eotsd/daemon/start.go
@@ -34,11 +34,10 @@ var StartCommand = cli.Command{
 }
 
 func startFn(ctx *cli.Context) error {
-	homePath, err := filepath.Abs(ctx.String(homeFlag))
+	homePath, err := getHomeFlag(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to load home flag: %w", err)
 	}
-	homePath = util.CleanAndExpandPath(homePath)
 
 	cfg, err := config.LoadConfig(homePath)
 	if err != nil {
@@ -78,4 +77,12 @@ func startFn(ctx *cli.Context) error {
 	eotsServer := eotsservice.NewEOTSManagerServer(cfg, logger, eotsManager, dbBackend, shutdownInterceptor)
 
 	return eotsServer.RunUntilShutdown()
+}
+
+func getHomeFlag(ctx *cli.Context) (string, error) {
+	homePath, err := filepath.Abs(ctx.String(homeFlag))
+	if err != nil {
+		return "", err
+	}
+	return util.CleanAndExpandPath(homePath), nil
 }

--- a/eotsmanager/cmd/eotsd/main.go
+++ b/eotsmanager/cmd/eotsd/main.go
@@ -2,8 +2,11 @@ package main
 
 import (
 	"fmt"
-	"github.com/urfave/cli"
 	"os"
+
+	"github.com/urfave/cli"
+
+	dcli "github.com/babylonchain/finality-provider/eotsmanager/cmd/eotsd/daemon"
 )
 
 func fatal(err error) {
@@ -15,7 +18,7 @@ func main() {
 	app := cli.NewApp()
 	app.Name = "eotsd"
 	app.Usage = "Extractable One Time Signature Daemon (eotsd)."
-	app.Commands = append(app.Commands, startCommand, initCommand)
+	app.Commands = append(app.Commands, dcli.StartCommand, dcli.InitCommand)
 
 	if err := app.Run(os.Args); err != nil {
 		fatal(err)

--- a/eotsmanager/cmd/eotsd/main.go
+++ b/eotsmanager/cmd/eotsd/main.go
@@ -19,6 +19,7 @@ func main() {
 	app.Name = "eotsd"
 	app.Usage = "Extractable One Time Signature Daemon (eotsd)."
 	app.Commands = append(app.Commands, dcli.StartCommand, dcli.InitCommand)
+	app.Commands = append(app.Commands, dcli.KeysCommands...)
 
 	if err := app.Run(os.Args); err != nil {
 		fatal(err)

--- a/eotsmanager/localmanager.go
+++ b/eotsmanager/localmanager.go
@@ -48,7 +48,7 @@ func NewLocalEOTSManager(homeDir string, eotsCfg *config.Config, dbbackend kvdb.
 		return nil, fmt.Errorf("failed to initialize store: %w", err)
 	}
 
-	kr, err := initKeyring(homeDir, eotsCfg, inputReader)
+	kr, err := initKeyring(homeDir, eotsCfg.KeyringBackend, inputReader)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize keyring: %w", err)
 	}
@@ -64,10 +64,10 @@ func NewLocalEOTSManager(homeDir string, eotsCfg *config.Config, dbbackend kvdb.
 	}, nil
 }
 
-func initKeyring(homeDir string, eotsCfg *config.Config, inputReader *strings.Reader) (keyring.Keyring, error) {
+func initKeyring(homeDir, keyringBackend string, inputReader *strings.Reader) (keyring.Keyring, error) {
 	return keyring.New(
 		"eots-manager",
-		eotsCfg.KeyringBackend,
+		keyringBackend,
 		homeDir,
 		inputReader,
 		codec.MakeCodec(),

--- a/eotsmanager/localmanager.go
+++ b/eotsmanager/localmanager.go
@@ -18,7 +18,6 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/babylonchain/finality-provider/codec"
-	"github.com/babylonchain/finality-provider/eotsmanager/config"
 	"github.com/babylonchain/finality-provider/eotsmanager/store"
 	eotstypes "github.com/babylonchain/finality-provider/eotsmanager/types"
 	fpkeyring "github.com/babylonchain/finality-provider/keyring"
@@ -40,7 +39,7 @@ type LocalEOTSManager struct {
 	metrics *metrics.EotsMetrics
 }
 
-func NewLocalEOTSManager(homeDir string, eotsCfg *config.Config, dbbackend kvdb.Backend, logger *zap.Logger) (*LocalEOTSManager, error) {
+func NewLocalEOTSManager(homeDir, keyringBackend string, dbbackend kvdb.Backend, logger *zap.Logger) (*LocalEOTSManager, error) {
 	inputReader := strings.NewReader("")
 
 	es, err := store.NewEOTSStore(dbbackend)
@@ -48,7 +47,7 @@ func NewLocalEOTSManager(homeDir string, eotsCfg *config.Config, dbbackend kvdb.
 		return nil, fmt.Errorf("failed to initialize store: %w", err)
 	}
 
-	kr, err := initKeyring(homeDir, eotsCfg.KeyringBackend, inputReader)
+	kr, err := initKeyring(homeDir, keyringBackend, inputReader)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize keyring: %w", err)
 	}

--- a/eotsmanager/localmanager_test.go
+++ b/eotsmanager/localmanager_test.go
@@ -39,7 +39,7 @@ func FuzzCreateKey(f *testing.F) {
 			require.NoError(t, err)
 		}()
 
-		lm, err := eotsmanager.NewLocalEOTSManager(homeDir, eotsCfg, dbBackend, zap.NewNop())
+		lm, err := eotsmanager.NewLocalEOTSManager(homeDir, eotsCfg.KeyringBackend, dbBackend, zap.NewNop())
 		require.NoError(t, err)
 
 		fpPk, err := lm.CreateKey(fpName, passphrase, hdPath)
@@ -73,7 +73,7 @@ func FuzzCreateMasterRandPair(f *testing.F) {
 			require.NoError(t, err)
 		}()
 		require.NoError(t, err)
-		lm, err := eotsmanager.NewLocalEOTSManager(homeDir, eotsCfg, dbBackend, zap.NewNop())
+		lm, err := eotsmanager.NewLocalEOTSManager(homeDir, eotsCfg.KeyringBackend, dbBackend, zap.NewNop())
 		require.NoError(t, err)
 
 		fpPk, err := lm.CreateKey(fpName, passphrase, hdPath)

--- a/finality-provider/service/app_test.go
+++ b/finality-provider/service/app_test.go
@@ -37,7 +37,7 @@ func FuzzRegisterFinalityProvider(f *testing.F) {
 		eotsCfg := eotscfg.DefaultConfigWithHomePath(eotsHomeDir)
 		dbBackend, err := eotsCfg.DatabaseConfig.GetDbBackend()
 		require.NoError(t, err)
-		em, err := eotsmanager.NewLocalEOTSManager(eotsHomeDir, eotsCfg, dbBackend, logger)
+		em, err := eotsmanager.NewLocalEOTSManager(eotsHomeDir, eotsCfg.KeyringBackend, dbBackend, logger)
 		require.NoError(t, err)
 		defer func() {
 			dbBackend.Close()

--- a/finality-provider/service/fp_instance_test.go
+++ b/finality-provider/service/fp_instance_test.go
@@ -67,7 +67,7 @@ func startFinalityProviderAppWithRegisteredFp(t *testing.T, r *rand.Rand, cc cli
 	eotsCfg := eotscfg.DefaultConfigWithHomePath(eotsHomeDir)
 	eotsdb, err := eotsCfg.DatabaseConfig.GetDbBackend()
 	require.NoError(t, err)
-	em, err := eotsmanager.NewLocalEOTSManager(eotsHomeDir, eotsCfg, eotsdb, logger)
+	em, err := eotsmanager.NewLocalEOTSManager(eotsHomeDir, eotsCfg.KeyringBackend, eotsdb, logger)
 	require.NoError(t, err)
 
 	// create finality-provider app with randomized config

--- a/finality-provider/service/fp_manager_test.go
+++ b/finality-provider/service/fp_manager_test.go
@@ -100,7 +100,7 @@ func newFinalityProviderManagerWithRegisteredFp(t *testing.T, r *rand.Rand, cc c
 	eotsCfg := eotscfg.DefaultConfigWithHomePath(eotsHomeDir)
 	eotsdb, err := eotsCfg.DatabaseConfig.GetDbBackend()
 	require.NoError(t, err)
-	em, err := eotsmanager.NewLocalEOTSManager(eotsHomeDir, eotsCfg, eotsdb, logger)
+	em, err := eotsmanager.NewLocalEOTSManager(eotsHomeDir, eotsCfg.KeyringBackend, eotsdb, logger)
 	require.NoError(t, err)
 
 	// create finality-provider app with randomized config

--- a/itest/eotsmanager_handler.go
+++ b/itest/eotsmanager_handler.go
@@ -25,7 +25,7 @@ func NewEOTSServerHandler(t *testing.T, cfg *config.Config, eotsHomeDir string) 
 	dbBackend, err := cfg.DatabaseConfig.GetDbBackend()
 	require.NoError(t, err)
 	logger := zap.NewNop()
-	eotsManager, err := eotsmanager.NewLocalEOTSManager(eotsHomeDir, cfg, dbBackend, logger)
+	eotsManager, err := eotsmanager.NewLocalEOTSManager(eotsHomeDir, cfg.KeyringBackend, dbBackend, logger)
 	require.NoError(t, err)
 
 	eotsServer := service.NewEOTSManagerServer(cfg, logger, eotsManager, dbBackend, shutdownInterceptor)

--- a/keyring/keyringcontroller_test.go
+++ b/keyring/keyringcontroller_test.go
@@ -43,7 +43,7 @@ func FuzzCreatePoP(f *testing.F) {
 		eotsCfg := eotscfg.DefaultConfigWithHomePath(eotsHome)
 		dbBackend, err := eotsCfg.DatabaseConfig.GetDbBackend()
 		require.NoError(t, err)
-		em, err := eotsmanager.NewLocalEOTSManager(eotsHome, eotsCfg, dbBackend, zap.NewNop())
+		em, err := eotsmanager.NewLocalEOTSManager(eotsHome, eotsCfg.KeyringBackend, dbBackend, zap.NewNop())
 		defer func() {
 			dbBackend.Close()
 			err := os.RemoveAll(eotsHome)


### PR DESCRIPTION
- Moved files to new package `daemon` to avoid having more than one file in `main` package
- Add new command `eotsd keys add` with the option to `--recover` from mnemonic  
- Set data dir on config to created data dir in `eotsd init` instead of the default


closes: #306 