### PR TITLE
feat: Split into ClientController and ConsumerController

### DIFF
--- a/clientcontroller/babylon.go
+++ b/clientcontroller/babylon.go
@@ -150,31 +150,6 @@ func (bc *BabylonController) RegisterFinalityProvider(
 	return &types.TxResponse{TxHash: res.TxHash, Events: res.Events}, registeredEpoch, nil
 }
 
-func (bc *BabylonController) QueryFinalityProviderSlashed(fpPk *btcec.PublicKey) (bool, error) {
-	fpPubKey := bbntypes.NewBIP340PubKeyFromBTCPK(fpPk)
-	res, err := bc.bbnClient.QueryClient.FinalityProvider(fpPubKey.MarshalHex())
-	if err != nil {
-		return false, fmt.Errorf("failed to query the finality provider %s: %v", fpPubKey.MarshalHex(), err)
-	}
-
-	slashed := res.FinalityProvider.SlashedBtcHeight > 0
-
-	return slashed, nil
-}
-
-// QueryFinalityProviderVotingPower queries the voting power of the finality provider at a given height
-func (bc *BabylonController) QueryFinalityProviderVotingPower(fpPk *btcec.PublicKey, blockHeight uint64) (uint64, error) {
-	res, err := bc.bbnClient.QueryClient.FinalityProviderPowerAtHeight(
-		bbntypes.NewBIP340PubKeyFromBTCPK(fpPk).MarshalHex(),
-		blockHeight,
-	)
-	if err != nil {
-		return 0, fmt.Errorf("failed to query the finality provider's voting power at height %d: %w", blockHeight, err)
-	}
-
-	return res.VotingPower, nil
-}
-
 // QueryFinalityProviderRegisteredEpoch queries the registered epoch of the finality provider
 func (bc *BabylonController) QueryFinalityProviderRegisteredEpoch(fpPk *btcec.PublicKey) (uint64, error) {
 	res, err := bc.bbnClient.QueryClient.FinalityProvider(

--- a/clientcontroller/babylon_consumer.go
+++ b/clientcontroller/babylon_consumer.go
@@ -1,0 +1,314 @@
+package clientcontroller
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	sdkErr "cosmossdk.io/errors"
+	"cosmossdk.io/math"
+	bbnclient "github.com/babylonchain/babylon/client/client"
+	bbntypes "github.com/babylonchain/babylon/types"
+	btcstakingtypes "github.com/babylonchain/babylon/x/btcstaking/types"
+	finalitytypes "github.com/babylonchain/babylon/x/finality/types"
+	fpcfg "github.com/babylonchain/finality-provider/finality-provider/config"
+	"github.com/babylonchain/finality-provider/types"
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkquery "github.com/cosmos/cosmos-sdk/types/query"
+	sttypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/cosmos/relayer/v2/relayer/provider"
+	"go.uber.org/zap"
+)
+
+var _ ConsumerClientController = &BabylonConsumerController{}
+
+type BabylonConsumerController struct {
+	bbnClient *bbnclient.Client
+	cfg       *fpcfg.BBNConfig
+	btcParams *chaincfg.Params
+	logger    *zap.Logger
+}
+
+func NewBabylonConsumerController(
+	cfg *fpcfg.BBNConfig,
+	btcParams *chaincfg.Params,
+	logger *zap.Logger,
+) (*BabylonConsumerController, error) {
+
+	bbnConfig := fpcfg.BBNConfigToBabylonConfig(cfg)
+
+	if err := bbnConfig.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid config for Babylon client: %w", err)
+	}
+
+	bc, err := bbnclient.New(
+		&bbnConfig,
+		logger,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Babylon client: %w", err)
+	}
+
+	return &BabylonConsumerController{
+		bc,
+		cfg,
+		btcParams,
+		logger,
+	}, nil
+}
+
+func (bc *BabylonConsumerController) mustGetTxSigner() string {
+	signer := bc.GetKeyAddress()
+	prefix := bc.cfg.AccountPrefix
+	return sdk.MustBech32ifyAddressBytes(prefix, signer)
+}
+
+func (bc *BabylonConsumerController) GetKeyAddress() sdk.AccAddress {
+	// get key address, retrieves address based on key name which is configured in
+	// cfg *stakercfg.BBNConfig. If this fails, it means we have misconfiguration problem
+	// and we should panic.
+	// This is checked at the start of BabylonConsumerController, so if it fails something is really wrong
+
+	keyRec, err := bc.bbnClient.GetKeyring().Key(bc.cfg.Key)
+
+	if err != nil {
+		panic(fmt.Sprintf("Failed to get key address: %s", err))
+	}
+
+	addr, err := keyRec.GetAddress()
+
+	if err != nil {
+		panic(fmt.Sprintf("Failed to get key address: %s", err))
+	}
+
+	return addr
+}
+
+func (bc *BabylonConsumerController) reliablySendMsg(msg sdk.Msg, expectedErrs []*sdkErr.Error, unrecoverableErrs []*sdkErr.Error) (*provider.RelayerTxResponse, error) {
+	return bc.reliablySendMsgs([]sdk.Msg{msg}, expectedErrs, unrecoverableErrs)
+}
+
+func (bc *BabylonConsumerController) reliablySendMsgs(msgs []sdk.Msg, expectedErrs []*sdkErr.Error, unrecoverableErrs []*sdkErr.Error) (*provider.RelayerTxResponse, error) {
+	return bc.bbnClient.ReliablySendMsgs(
+		context.Background(),
+		msgs,
+		expectedErrs,
+		unrecoverableErrs,
+	)
+}
+
+// RegisterFinalityProvider registers a finality provider via a MsgCreateFinalityProvider to Babylon
+// it returns tx hash, registered epoch, and error
+func (bc *BabylonConsumerController) RegisterFinalityProvider(
+	chainPk []byte,
+	fpPk *btcec.PublicKey,
+	pop []byte,
+	commission *math.LegacyDec,
+	description []byte,
+	masterPubRand string,
+) (*types.TxResponse, uint64, error) {
+	var bbnPop btcstakingtypes.ProofOfPossession
+	if err := bbnPop.Unmarshal(pop); err != nil {
+		return nil, 0, fmt.Errorf("invalid proof-of-possession: %w", err)
+	}
+
+	var sdkDescription sttypes.Description
+	if err := sdkDescription.Unmarshal(description); err != nil {
+		return nil, 0, fmt.Errorf("invalid description: %w", err)
+	}
+
+	msg := &btcstakingtypes.MsgCreateFinalityProvider{
+		Signer:        bc.mustGetTxSigner(),
+		BabylonPk:     &secp256k1.PubKey{Key: chainPk},
+		BtcPk:         bbntypes.NewBIP340PubKeyFromBTCPK(fpPk),
+		Pop:           &bbnPop,
+		Commission:    commission,
+		Description:   &sdkDescription,
+		MasterPubRand: masterPubRand,
+	}
+
+	res, err := bc.reliablySendMsg(msg, emptyErrs, emptyErrs)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	registeredEpoch, err := bc.QueryFinalityProviderRegisteredEpoch(fpPk)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return &types.TxResponse{TxHash: res.TxHash, Events: res.Events}, registeredEpoch, nil
+}
+
+// SubmitFinalitySig submits the finality signature via a MsgAddVote to Babylon
+func (bc *BabylonConsumerController) SubmitFinalitySig(fpPk *btcec.PublicKey, blockHeight uint64, blockHash []byte, sig *btcec.ModNScalar) (*types.TxResponse, error) {
+	msg := &finalitytypes.MsgAddFinalitySig{
+		Signer:       bc.mustGetTxSigner(),
+		FpBtcPk:      bbntypes.NewBIP340PubKeyFromBTCPK(fpPk),
+		BlockHeight:  blockHeight,
+		BlockAppHash: blockHash,
+		FinalitySig:  bbntypes.NewSchnorrEOTSSigFromModNScalar(sig),
+	}
+
+	unrecoverableErrs := []*sdkErr.Error{
+		finalitytypes.ErrInvalidFinalitySig,
+		finalitytypes.ErrPubRandNotFound,
+		btcstakingtypes.ErrFpAlreadySlashed,
+	}
+
+	res, err := bc.reliablySendMsg(msg, emptyErrs, unrecoverableErrs)
+	if err != nil {
+		return nil, err
+	}
+
+	return &types.TxResponse{TxHash: res.TxHash, Events: res.Events}, nil
+}
+
+// SubmitBatchFinalitySigs submits a batch of finality signatures to Babylon
+func (bc *BabylonConsumerController) SubmitBatchFinalitySigs(fpPk *btcec.PublicKey, blocks []*types.BlockInfo, sigs []*btcec.ModNScalar) (*types.TxResponse, error) {
+	if len(blocks) != len(sigs) {
+		return nil, fmt.Errorf("the number of blocks %v should match the number of finality signatures %v", len(blocks), len(sigs))
+	}
+
+	msgs := make([]sdk.Msg, 0, len(blocks))
+	for i, b := range blocks {
+		msg := &finalitytypes.MsgAddFinalitySig{
+			Signer:       bc.mustGetTxSigner(),
+			FpBtcPk:      bbntypes.NewBIP340PubKeyFromBTCPK(fpPk),
+			BlockHeight:  b.Height,
+			BlockAppHash: b.Hash,
+			FinalitySig:  bbntypes.NewSchnorrEOTSSigFromModNScalar(sigs[i]),
+		}
+		msgs = append(msgs, msg)
+	}
+
+	unrecoverableErrs := []*sdkErr.Error{
+		finalitytypes.ErrInvalidFinalitySig,
+		finalitytypes.ErrPubRandNotFound,
+		btcstakingtypes.ErrFpAlreadySlashed,
+	}
+
+	res, err := bc.reliablySendMsgs(msgs, emptyErrs, unrecoverableErrs)
+	if err != nil {
+		return nil, err
+	}
+
+	return &types.TxResponse{TxHash: res.TxHash, Events: res.Events}, nil
+}
+
+// QueryFinalityProviderRegisteredEpoch queries the registered epoch of the finality provider
+func (bc *BabylonConsumerController) QueryFinalityProviderRegisteredEpoch(fpPk *btcec.PublicKey) (uint64, error) {
+	res, err := bc.bbnClient.QueryClient.FinalityProvider(
+		bbntypes.NewBIP340PubKeyFromBTCPK(fpPk).MarshalHex(),
+	)
+	if err != nil {
+		return 0, fmt.Errorf("failed to query finality provider registered epoch: %w", err)
+	}
+
+	return res.FinalityProvider.RegisteredEpoch, nil
+}
+
+func (bc *BabylonConsumerController) QueryLatestFinalizedBlocks(count uint64) ([]*types.BlockInfo, error) {
+	return bc.queryLatestBlocks(nil, count, finalitytypes.QueriedBlockStatus_FINALIZED, true)
+}
+
+func (bc *BabylonConsumerController) QueryBlocks(startHeight, endHeight, limit uint64) ([]*types.BlockInfo, error) {
+	if endHeight < startHeight {
+		return nil, fmt.Errorf("the startHeight %v should not be higher than the endHeight %v", startHeight, endHeight)
+	}
+	count := endHeight - startHeight + 1
+	if count > limit {
+		count = limit
+	}
+	return bc.queryLatestBlocks(sdk.Uint64ToBigEndian(startHeight), count, finalitytypes.QueriedBlockStatus_ANY, false)
+}
+
+func (bc *BabylonConsumerController) queryLatestBlocks(startKey []byte, count uint64, status finalitytypes.QueriedBlockStatus, reverse bool) ([]*types.BlockInfo, error) {
+	var blocks []*types.BlockInfo
+	pagination := &sdkquery.PageRequest{
+		Limit:   count,
+		Reverse: reverse,
+		Key:     startKey,
+	}
+
+	res, err := bc.bbnClient.QueryClient.ListBlocks(status, pagination)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query finalized blocks: %v", err)
+	}
+
+	for _, b := range res.Blocks {
+		ib := &types.BlockInfo{
+			Height: b.Height,
+			Hash:   b.AppHash,
+		}
+		blocks = append(blocks, ib)
+	}
+
+	return blocks, nil
+}
+
+func getContextWithCancel(timeout time.Duration) (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	return ctx, cancel
+}
+
+func (bc *BabylonConsumerController) QueryBlock(height uint64) (*types.BlockInfo, error) {
+	res, err := bc.bbnClient.QueryClient.Block(height)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query indexed block at height %v: %w", height, err)
+	}
+
+	return &types.BlockInfo{
+		Height:    height,
+		Hash:      res.Block.AppHash,
+		Finalized: res.Block.Finalized,
+	}, nil
+}
+
+func (bc *BabylonConsumerController) QueryActivatedHeight() (uint64, error) {
+	res, err := bc.bbnClient.QueryClient.ActivatedHeight()
+	if err != nil {
+		return 0, fmt.Errorf("failed to query activated height: %w", err)
+	}
+
+	return res.Height, nil
+}
+
+func (bc *BabylonConsumerController) QueryBestBlock() (*types.BlockInfo, error) {
+	blocks, err := bc.queryLatestBlocks(nil, 1, finalitytypes.QueriedBlockStatus_ANY, true)
+	if err != nil || len(blocks) != 1 {
+		// try query comet block if the index block query is not available
+		return bc.queryCometBestBlock()
+	}
+
+	return blocks[0], nil
+}
+
+func (bc *BabylonConsumerController) queryCometBestBlock() (*types.BlockInfo, error) {
+	ctx, cancel := getContextWithCancel(bc.cfg.Timeout)
+	// this will return 20 items at max in the descending order (highest first)
+	chainInfo, err := bc.bbnClient.RPCClient.BlockchainInfo(ctx, 0, 0)
+	defer cancel()
+
+	if err != nil {
+		return nil, err
+	}
+
+	// Returning response directly, if header with specified number did not exist
+	// at request will contain nil header
+	return &types.BlockInfo{
+		Height: uint64(chainInfo.BlockMetas[0].Header.Height),
+		Hash:   chainInfo.BlockMetas[0].Header.AppHash,
+	}, nil
+}
+
+func (bc *BabylonConsumerController) Close() error {
+	if !bc.bbnClient.IsRunning() {
+		return nil
+	}
+
+	return bc.bbnClient.Stop()
+}

--- a/clientcontroller/babylon_consumer.go
+++ b/clientcontroller/babylon_consumer.go
@@ -20,7 +20,7 @@ import (
 	"go.uber.org/zap"
 )
 
-var _ ConsumerClientController = &BabylonConsumerController{}
+var _ ConsumerController = &BabylonConsumerController{}
 
 type BabylonConsumerController struct {
 	bbnClient *bbnclient.Client

--- a/clientcontroller/interface.go
+++ b/clientcontroller/interface.go
@@ -62,7 +62,7 @@ func NewClientController(chainName string, bbnConfig *fpcfg.BBNConfig, netParams
 	return cc, err
 }
 
-type ConsumerClientController interface {
+type ConsumerController interface {
 
 	// SubmitFinalitySig submits the finality signature to the consumer chain
 	SubmitFinalitySig(fpPk *btcec.PublicKey, blockHeight uint64, blockHash []byte, sig *btcec.ModNScalar) (*types.TxResponse, error)
@@ -97,9 +97,9 @@ type ConsumerClientController interface {
 	Close() error
 }
 
-func NewConsumerClientController(chainName string, bbnConfig *fpcfg.BBNConfig, netParams *chaincfg.Params, logger *zap.Logger) (ConsumerClientController, error) {
+func NewConsumerController(chainName string, bbnConfig *fpcfg.BBNConfig, netParams *chaincfg.Params, logger *zap.Logger) (ConsumerController, error) {
 	var (
-		ccc ConsumerClientController
+		ccc ConsumerController
 		err error
 	)
 	switch chainName {

--- a/clientcontroller/interface.go
+++ b/clientcontroller/interface.go
@@ -32,6 +32,12 @@ type ClientController interface {
 
 	// Note: the following queries are only for PoC
 
+	// QueryFinalityProviderVotingPower queries the voting power of the finality provider at a given height
+	QueryFinalityProviderVotingPower(fpPk *btcec.PublicKey, blockHeight uint64) (uint64, error)
+
+	// QueryFinalityProviderSlashed queries if the finality provider is slashed
+	QueryFinalityProviderSlashed(fpPk *btcec.PublicKey) (bool, error)
+
 	// QueryLastFinalizedEpoch returns the last finalised epoch of Babylon
 	QueryLastFinalizedEpoch() (uint64, error)
 

--- a/clientcontroller/interface.go
+++ b/clientcontroller/interface.go
@@ -14,6 +14,7 @@ import (
 
 const (
 	babylonConsumerChainName = "babylon"
+	evmConsumerChainName     = "evm"
 )
 
 type ClientController interface {
@@ -29,12 +30,6 @@ type ClientController interface {
 		masterPubRand string,
 	) (*types.TxResponse, uint64, error)
 
-	// SubmitFinalitySig submits the finality signature to the consumer chain
-	SubmitFinalitySig(fpPk *btcec.PublicKey, blockHeight uint64, blockHash []byte, sig *btcec.ModNScalar) (*types.TxResponse, error)
-
-	// SubmitBatchFinalitySigs submits a batch of finality signatures to the consumer chain
-	SubmitBatchFinalitySigs(fpPk *btcec.PublicKey, blocks []*types.BlockInfo, sigs []*btcec.ModNScalar) (*types.TxResponse, error)
-
 	// Note: the following queries are only for PoC
 
 	// QueryFinalityProviderVotingPower queries the voting power of the finality provider at a given height
@@ -42,22 +37,6 @@ type ClientController interface {
 
 	// QueryFinalityProviderSlashed queries if the finality provider is slashed
 	QueryFinalityProviderSlashed(fpPk *btcec.PublicKey) (bool, error)
-
-	// QueryLatestFinalizedBlocks returns the latest finalized blocks
-	QueryLatestFinalizedBlocks(count uint64) ([]*types.BlockInfo, error)
-
-	// QueryBlock queries the block at the given height
-	QueryBlock(height uint64) (*types.BlockInfo, error)
-
-	// QueryBlocks returns a list of blocks from startHeight to endHeight
-	QueryBlocks(startHeight, endHeight, limit uint64) ([]*types.BlockInfo, error)
-
-	// QueryBestBlock queries the tip block of the consumer chain
-	QueryBestBlock() (*types.BlockInfo, error)
-
-	// QueryActivatedHeight returns the activated height of the consumer chain
-	// error will be returned if the consumer chain has not been activated
-	QueryActivatedHeight() (uint64, error)
 
 	// QueryLastFinalizedEpoch returns the last finalised epoch of Babylon
 	QueryLastFinalizedEpoch() (uint64, error)
@@ -81,4 +60,51 @@ func NewClientController(chainName string, bbnConfig *fpcfg.BBNConfig, netParams
 	}
 
 	return cc, err
+}
+
+type ConsumerClientController interface {
+
+	// SubmitFinalitySig submits the finality signature to the consumer chain
+	SubmitFinalitySig(fpPk *btcec.PublicKey, blockHeight uint64, blockHash []byte, sig *btcec.ModNScalar) (*types.TxResponse, error)
+
+	// SubmitBatchFinalitySigs submits a batch of finality signatures to the consumer chain
+	SubmitBatchFinalitySigs(fpPk *btcec.PublicKey, blocks []*types.BlockInfo, sigs []*btcec.ModNScalar) (*types.TxResponse, error)
+
+	// Note: the following queries are only for PoC
+
+	// QueryLatestFinalizedBlocks returns the latest finalized blocks
+	QueryLatestFinalizedBlocks(count uint64) ([]*types.BlockInfo, error)
+
+	// QueryBlock queries the block at the given height
+	QueryBlock(height uint64) (*types.BlockInfo, error)
+
+	// QueryBlocks returns a list of blocks from startHeight to endHeight
+	QueryBlocks(startHeight, endHeight, limit uint64) ([]*types.BlockInfo, error)
+
+	// QueryBestBlock queries the tip block of the consumer chain
+	QueryBestBlock() (*types.BlockInfo, error)
+
+	// QueryActivatedHeight returns the activated height of the consumer chain
+	// error will be returned if the consumer chain has not been activated
+	QueryActivatedHeight() (uint64, error)
+
+	Close() error
+}
+
+func NewConsumerClientController(chainName string, bbnConfig *fpcfg.BBNConfig, netParams *chaincfg.Params, logger *zap.Logger) (ConsumerClientController, error) {
+	var (
+		ccc ConsumerClientController
+		err error
+	)
+	switch chainName {
+	case babylonConsumerChainName:
+		ccc, err = NewBabylonConsumerController(bbnConfig, netParams, logger)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create Babylon rpc client: %w", err)
+		}
+	default:
+		return nil, fmt.Errorf("unsupported consumer chain")
+	}
+
+	return ccc, err
 }

--- a/clientcontroller/interface.go
+++ b/clientcontroller/interface.go
@@ -32,12 +32,6 @@ type ClientController interface {
 
 	// Note: the following queries are only for PoC
 
-	// QueryFinalityProviderVotingPower queries the voting power of the finality provider at a given height
-	QueryFinalityProviderVotingPower(fpPk *btcec.PublicKey, blockHeight uint64) (uint64, error)
-
-	// QueryFinalityProviderSlashed queries if the finality provider is slashed
-	QueryFinalityProviderSlashed(fpPk *btcec.PublicKey) (bool, error)
-
 	// QueryLastFinalizedEpoch returns the last finalised epoch of Babylon
 	QueryLastFinalizedEpoch() (uint64, error)
 
@@ -71,6 +65,12 @@ type ConsumerClientController interface {
 	SubmitBatchFinalitySigs(fpPk *btcec.PublicKey, blocks []*types.BlockInfo, sigs []*btcec.ModNScalar) (*types.TxResponse, error)
 
 	// Note: the following queries are only for PoC
+
+	// QueryFinalityProviderVotingPower queries the voting power of the finality provider at a given height
+	QueryFinalityProviderVotingPower(fpPk *btcec.PublicKey, blockHeight uint64) (uint64, error)
+
+	// QueryFinalityProviderSlashed queries if the finality provider is slashed
+	QueryFinalityProviderSlashed(fpPk *btcec.PublicKey) (bool, error)
 
 	// QueryLatestFinalizedBlocks returns the latest finalized blocks
 	QueryLatestFinalizedBlocks(count uint64) ([]*types.BlockInfo, error)

--- a/finality-provider/service/app.go
+++ b/finality-provider/service/app.go
@@ -35,13 +35,13 @@ type FinalityProviderApp struct {
 	wg   sync.WaitGroup
 	quit chan struct{}
 
-	cc         clientcontroller.ClientController
-	consumerCc clientcontroller.ConsumerClientController
-	kr         keyring.Keyring
-	fps        *store.FinalityProviderStore
-	config     *fpcfg.Config
-	logger     *zap.Logger
-	input      *strings.Reader
+	cc          clientcontroller.ClientController
+	consumerCon clientcontroller.ConsumerController
+	kr          keyring.Keyring
+	fps         *store.FinalityProviderStore
+	config      *fpcfg.Config
+	logger      *zap.Logger
+	input       *strings.Reader
 
 	fpManager   *FinalityProviderManager
 	eotsManager eotsmanager.EOTSManager
@@ -62,7 +62,7 @@ func NewFinalityProviderAppFromConfig(
 	if err != nil {
 		return nil, fmt.Errorf("failed to create rpc client for the consumer chain %s: %v", cfg.ChainName, err)
 	}
-	ccc, err := clientcontroller.NewConsumerClientController(cfg.ChainName, cfg.BabylonConfig, &cfg.BTCNetParams, logger)
+	consumerCon, err := clientcontroller.NewConsumerController(cfg.ChainName, cfg.BabylonConfig, &cfg.BTCNetParams, logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create rpc client for the consumer chain %s: %v", cfg.ChainName, err)
 	}
@@ -75,13 +75,13 @@ func NewFinalityProviderAppFromConfig(
 
 	logger.Info("successfully connected to a remote EOTS manager", zap.String("address", cfg.EOTSManagerAddress))
 
-	return NewFinalityProviderApp(cfg, cc, ccc, em, db, logger)
+	return NewFinalityProviderApp(cfg, cc, consumerCon, em, db, logger)
 }
 
 func NewFinalityProviderApp(
 	config *fpcfg.Config,
 	cc clientcontroller.ClientController,
-	consumerCc clientcontroller.ConsumerClientController,
+	consumerCon clientcontroller.ConsumerController,
 	em eotsmanager.EOTSManager,
 	db kvdb.Backend,
 	logger *zap.Logger,
@@ -104,14 +104,14 @@ func NewFinalityProviderApp(
 
 	fpMetrics := metrics.NewFpMetrics()
 
-	fpm, err := NewFinalityProviderManager(fpStore, config, cc, consumerCc, em, fpMetrics, logger)
+	fpm, err := NewFinalityProviderManager(fpStore, config, cc, consumerCon, em, fpMetrics, logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create finality-provider manager: %w", err)
 	}
 
 	return &FinalityProviderApp{
 		cc:                                  cc,
-		consumerCc:                          consumerCc,
+		consumerCon:                         consumerCon,
 		fps:                                 fpStore,
 		kr:                                  kr,
 		config:                              config,
@@ -231,7 +231,7 @@ func (app *FinalityProviderApp) getFpPrivKey(fpPk []byte) (*btcec.PrivateKey, er
 
 // SyncFinalityProviderStatus syncs the status of the finality-providers
 func (app *FinalityProviderApp) SyncFinalityProviderStatus() error {
-	latestBlock, err := app.consumerCc.QueryBestBlock()
+	latestBlock, err := app.consumerCon.QueryBestBlock()
 	if err != nil {
 		return err
 	}
@@ -242,7 +242,7 @@ func (app *FinalityProviderApp) SyncFinalityProviderStatus() error {
 	}
 
 	for _, fp := range fps {
-		vp, err := app.consumerCc.QueryFinalityProviderVotingPower(fp.BtcPk, latestBlock.Height)
+		vp, err := app.consumerCon.QueryFinalityProviderVotingPower(fp.BtcPk, latestBlock.Height)
 		if err != nil {
 			// if error occured then the finality-provider is not registered in the Babylon chain yet
 			continue

--- a/finality-provider/service/app.go
+++ b/finality-provider/service/app.go
@@ -36,6 +36,7 @@ type FinalityProviderApp struct {
 	quit chan struct{}
 
 	cc     clientcontroller.ClientController
+	ccc    clientcontroller.ConsumerClientController
 	kr     keyring.Keyring
 	fps    *store.FinalityProviderStore
 	config *fpcfg.Config
@@ -61,7 +62,10 @@ func NewFinalityProviderAppFromConfig(
 	if err != nil {
 		return nil, fmt.Errorf("failed to create rpc client for the consumer chain %s: %v", cfg.ChainName, err)
 	}
-
+	ccc, err := clientcontroller.NewConsumerClientController(cfg.ChainName, cfg.BabylonConfig, &cfg.BTCNetParams, logger)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create rpc client for the consumer chain %s: %v", cfg.ChainName, err)
+	}
 	// if the EOTSManagerAddress is empty, run a local EOTS manager;
 	// otherwise connect a remote one with a gRPC client
 	em, err := client.NewEOTSManagerGRpcClient(cfg.EOTSManagerAddress)
@@ -71,12 +75,13 @@ func NewFinalityProviderAppFromConfig(
 
 	logger.Info("successfully connected to a remote EOTS manager", zap.String("address", cfg.EOTSManagerAddress))
 
-	return NewFinalityProviderApp(cfg, cc, em, db, logger)
+	return NewFinalityProviderApp(cfg, cc, ccc, em, db, logger)
 }
 
 func NewFinalityProviderApp(
 	config *fpcfg.Config,
 	cc clientcontroller.ClientController,
+	ccc clientcontroller.ConsumerClientController,
 	em eotsmanager.EOTSManager,
 	db kvdb.Backend,
 	logger *zap.Logger,
@@ -99,13 +104,14 @@ func NewFinalityProviderApp(
 
 	fpMetrics := metrics.NewFpMetrics()
 
-	fpm, err := NewFinalityProviderManager(fpStore, config, cc, em, fpMetrics, logger)
+	fpm, err := NewFinalityProviderManager(fpStore, config, cc, ccc, em, fpMetrics, logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create finality-provider manager: %w", err)
 	}
 
 	return &FinalityProviderApp{
 		cc:                                  cc,
+		ccc:                                 ccc,
 		fps:                                 fpStore,
 		kr:                                  kr,
 		config:                              config,
@@ -225,7 +231,7 @@ func (app *FinalityProviderApp) getFpPrivKey(fpPk []byte) (*btcec.PrivateKey, er
 
 // SyncFinalityProviderStatus syncs the status of the finality-providers
 func (app *FinalityProviderApp) SyncFinalityProviderStatus() error {
-	latestBlock, err := app.cc.QueryBestBlock()
+	latestBlock, err := app.ccc.QueryBestBlock()
 	if err != nil {
 		return err
 	}

--- a/finality-provider/service/app_test.go
+++ b/finality-provider/service/app_test.go
@@ -61,7 +61,7 @@ func FuzzRegisterFinalityProvider(f *testing.F) {
 		fpCfg.PollerConfig.StaticChainScanningStartHeight = randomStartingHeight
 		fpdb, err := fpCfg.DatabaseConfig.GetDbBackend()
 		require.NoError(t, err)
-		app, err := service.NewFinalityProviderApp(&fpCfg, mockClientController, em, fpdb, logger)
+		app, err := service.NewFinalityProviderApp(&fpCfg, mockClientController, mockClientController, em, fpdb, logger)
 		require.NoError(t, err)
 		defer func() {
 			err = fpdb.Close()

--- a/finality-provider/service/chain_poller_test.go
+++ b/finality-provider/service/chain_poller_test.go
@@ -50,7 +50,7 @@ func FuzzChainPoller_Start(f *testing.F) {
 		m := metrics.NewFpMetrics()
 		pollerCfg := fpcfg.DefaultChainPollerConfig()
 		pollerCfg.PollInterval = 10 * time.Millisecond
-		poller := service.NewChainPoller(zap.NewNop(), &pollerCfg, mockClientController, m)
+		poller := service.NewChainPoller(zap.NewNop(), &pollerCfg, mockClientController, mockClientController, m)
 		err := poller.Start(startHeight)
 		require.NoError(t, err)
 		defer func() {
@@ -101,7 +101,7 @@ func FuzzChainPoller_SkipHeight(f *testing.F) {
 		m := metrics.NewFpMetrics()
 		pollerCfg := fpcfg.DefaultChainPollerConfig()
 		pollerCfg.PollInterval = 1 * time.Second
-		poller := service.NewChainPoller(zap.NewNop(), &pollerCfg, mockClientController, m)
+		poller := service.NewChainPoller(zap.NewNop(), &pollerCfg, mockClientController, mockClientController, m)
 		// should expect error if the poller is not started
 		err := poller.SkipToHeight(skipHeight)
 		require.Error(t, err)

--- a/finality-provider/service/fastsync.go
+++ b/finality-provider/service/fastsync.go
@@ -33,7 +33,7 @@ func (fp *FinalityProviderInstance) FastSync(startHeight, endHeight uint64) (*Fa
 	// we may need several rounds to catch-up as we need to limit
 	// the catch-up distance for each round to avoid memory overflow
 	for startHeight <= endHeight {
-		blocks, err := fp.ccc.QueryBlocks(startHeight, endHeight, fp.cfg.FastSyncLimit)
+		blocks, err := fp.consumerCc.QueryBlocks(startHeight, endHeight, fp.cfg.FastSyncLimit)
 		if err != nil {
 			return nil, err
 		}

--- a/finality-provider/service/fastsync.go
+++ b/finality-provider/service/fastsync.go
@@ -33,7 +33,7 @@ func (fp *FinalityProviderInstance) FastSync(startHeight, endHeight uint64) (*Fa
 	// we may need several rounds to catch-up as we need to limit
 	// the catch-up distance for each round to avoid memory overflow
 	for startHeight <= endHeight {
-		blocks, err := fp.cc.QueryBlocks(startHeight, endHeight, fp.cfg.FastSyncLimit)
+		blocks, err := fp.ccc.QueryBlocks(startHeight, endHeight, fp.cfg.FastSyncLimit)
 		if err != nil {
 			return nil, err
 		}

--- a/finality-provider/service/fastsync.go
+++ b/finality-provider/service/fastsync.go
@@ -33,7 +33,7 @@ func (fp *FinalityProviderInstance) FastSync(startHeight, endHeight uint64) (*Fa
 	// we may need several rounds to catch-up as we need to limit
 	// the catch-up distance for each round to avoid memory overflow
 	for startHeight <= endHeight {
-		blocks, err := fp.consumerCc.QueryBlocks(startHeight, endHeight, fp.cfg.FastSyncLimit)
+		blocks, err := fp.consumerCon.QueryBlocks(startHeight, endHeight, fp.cfg.FastSyncLimit)
 		if err != nil {
 			return nil, err
 		}

--- a/finality-provider/service/fastsync_test.go
+++ b/finality-provider/service/fastsync_test.go
@@ -27,7 +27,7 @@ func FuzzFastSync(f *testing.F) {
 		mockClientController := testutil.PrepareMockedClientController(t, r, randomStartingHeight, currentHeight)
 		// mock finalised BTC timestamped
 		mockClientController.EXPECT().QueryLastFinalizedEpoch().Return(randomRegiteredEpoch, nil).AnyTimes()
-		_, fpIns, cleanUp := startFinalityProviderAppWithRegisteredFp(t, r, mockClientController, randomStartingHeight, randomRegiteredEpoch)
+		_, fpIns, cleanUp := startFinalityProviderAppWithRegisteredFp(t, r, mockClientController, mockClientController, randomStartingHeight, randomRegiteredEpoch)
 		defer cleanUp()
 
 		// mock voting power

--- a/finality-provider/service/fp_instance.go
+++ b/finality-provider/service/fp_instance.go
@@ -33,12 +33,12 @@ type FinalityProviderInstance struct {
 	state *fpState
 	cfg   *fpcfg.Config
 
-	logger     *zap.Logger
-	em         eotsmanager.EOTSManager
-	cc         clientcontroller.ClientController
-	consumerCc clientcontroller.ConsumerClientController
-	poller     *ChainPoller
-	metrics    *metrics.FpMetrics
+	logger      *zap.Logger
+	em          eotsmanager.EOTSManager
+	cc          clientcontroller.ClientController
+	consumerCon clientcontroller.ConsumerController
+	poller      *ChainPoller
+	metrics     *metrics.FpMetrics
 
 	// passphrase is used to unlock private keys
 	passphrase string
@@ -61,7 +61,7 @@ func NewFinalityProviderInstance(
 	cfg *fpcfg.Config,
 	s *store.FinalityProviderStore,
 	cc clientcontroller.ClientController,
-	consumerCc clientcontroller.ConsumerClientController,
+	consumerCon clientcontroller.ConsumerController,
 	em eotsmanager.EOTSManager,
 	metrics *metrics.FpMetrics,
 	passphrase string,
@@ -103,7 +103,7 @@ func NewFinalityProviderInstance(
 		passphrase:      passphrase,
 		em:              em,
 		cc:              cc,
-		consumerCc:      consumerCc,
+		consumerCon:     consumerCon,
 		metrics:         metrics,
 	}, nil
 }
@@ -123,7 +123,7 @@ func (fp *FinalityProviderInstance) Start() error {
 	fp.logger.Info("the finality-provider has been bootstrapped",
 		zap.String("pk", fp.GetBtcPkHex()), zap.Uint64("height", startHeight))
 
-	poller := NewChainPoller(fp.logger, fp.cfg.PollerConfig, fp.cc, fp.consumerCc, fp.metrics)
+	poller := NewChainPoller(fp.logger, fp.cfg.PollerConfig, fp.cc, fp.consumerCon, fp.metrics)
 
 	if err := poller.Start(startHeight + 1); err != nil {
 		return fmt.Errorf("failed to start the poller: %w", err)
@@ -325,7 +325,7 @@ func (fp *FinalityProviderInstance) tryFastSync(targetBlock *types.BlockInfo) (*
 	}
 
 	// get the last finalized height
-	lastFinalizedBlocks, err := fp.consumerCc.QueryLatestFinalizedBlocks(1)
+	lastFinalizedBlocks, err := fp.consumerCon.QueryLatestFinalizedBlocks(1)
 	if err != nil {
 		return nil, err
 	}
@@ -466,7 +466,7 @@ func (fp *FinalityProviderInstance) retrySubmitFinalitySignatureUntilBlockFinali
 }
 
 func (fp *FinalityProviderInstance) checkBlockFinalization(height uint64) (bool, error) {
-	b, err := fp.consumerCc.QueryBlock(height)
+	b, err := fp.consumerCon.QueryBlock(height)
 	if err != nil {
 		return false, err
 	}
@@ -482,7 +482,7 @@ func (fp *FinalityProviderInstance) SubmitFinalitySignature(b *types.BlockInfo) 
 	}
 
 	// send finality signature to the consumer chain
-	res, err := fp.consumerCc.SubmitFinalitySig(fp.GetBtcPk(), b.Height, b.Hash, eotsSig.ToModNScalar())
+	res, err := fp.consumerCon.SubmitFinalitySig(fp.GetBtcPk(), b.Height, b.Hash, eotsSig.ToModNScalar())
 	if err != nil {
 		return nil, fmt.Errorf("failed to send finality signature to the consumer chain: %w", err)
 	}
@@ -514,7 +514,7 @@ func (fp *FinalityProviderInstance) SubmitBatchFinalitySignatures(blocks []*type
 	}
 
 	// send finality signature to the consumer chain
-	res, err := fp.consumerCc.SubmitBatchFinalitySigs(fp.GetBtcPk(), blocks, sigs)
+	res, err := fp.consumerCon.SubmitBatchFinalitySigs(fp.GetBtcPk(), blocks, sigs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to send a batch of finality signatures to the consumer chain: %w", err)
 	}
@@ -552,7 +552,7 @@ func (fp *FinalityProviderInstance) TestSubmitFinalitySignatureAndExtractPrivKey
 	}
 
 	// send finality signature to the consumer chain
-	res, err := fp.consumerCc.SubmitFinalitySig(fp.GetBtcPk(), b.Height, b.Hash, eotsSig.ToModNScalar())
+	res, err := fp.consumerCon.SubmitFinalitySig(fp.GetBtcPk(), b.Height, b.Hash, eotsSig.ToModNScalar())
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to send finality signature to the consumer chain: %w", err)
 	}
@@ -613,7 +613,7 @@ func (fp *FinalityProviderInstance) getPollerStartingHeight() (uint64, error) {
 func (fp *FinalityProviderInstance) latestFinalizedBlocksWithRetry(count uint64) ([]*types.BlockInfo, error) {
 	var response []*types.BlockInfo
 	if err := retry.Do(func() error {
-		latestFinalisedBlock, err := fp.consumerCc.QueryLatestFinalizedBlocks(count)
+		latestFinalisedBlock, err := fp.consumerCon.QueryLatestFinalizedBlocks(count)
 		if err != nil {
 			return err
 		}
@@ -639,7 +639,7 @@ func (fp *FinalityProviderInstance) getLatestBlockWithRetry() (*types.BlockInfo,
 	)
 
 	if err := retry.Do(func() error {
-		latestBlock, err = fp.consumerCc.QueryBestBlock()
+		latestBlock, err = fp.consumerCon.QueryBestBlock()
 		if err != nil {
 			return err
 		}
@@ -666,7 +666,7 @@ func (fp *FinalityProviderInstance) GetVotingPowerWithRetry(height uint64) (uint
 	)
 
 	if err := retry.Do(func() error {
-		power, err = fp.consumerCc.QueryFinalityProviderVotingPower(fp.GetBtcPk(), height)
+		power, err = fp.consumerCon.QueryFinalityProviderVotingPower(fp.GetBtcPk(), height)
 		if err != nil {
 			return err
 		}
@@ -692,7 +692,7 @@ func (fp *FinalityProviderInstance) GetFinalityProviderSlashedWithRetry() (bool,
 	)
 
 	if err := retry.Do(func() error {
-		slashed, err = fp.consumerCc.QueryFinalityProviderSlashed(fp.GetBtcPk())
+		slashed, err = fp.consumerCon.QueryFinalityProviderSlashed(fp.GetBtcPk())
 		if err != nil {
 			return err
 		}

--- a/finality-provider/service/fp_instance_test.go
+++ b/finality-provider/service/fp_instance_test.go
@@ -60,7 +60,7 @@ func FuzzSubmitFinalitySig(f *testing.F) {
 	})
 }
 
-func startFinalityProviderAppWithRegisteredFp(t *testing.T, r *rand.Rand, cc clientcontroller.ClientController, ccc clientcontroller.ConsumerClientController, startingHeight uint64, registeredEpoch uint64) (*service.FinalityProviderApp, *service.FinalityProviderInstance, func()) {
+func startFinalityProviderAppWithRegisteredFp(t *testing.T, r *rand.Rand, cc clientcontroller.ClientController, consumerCon clientcontroller.ConsumerController, startingHeight uint64, registeredEpoch uint64) (*service.FinalityProviderApp, *service.FinalityProviderInstance, func()) {
 	logger := zap.NewNop()
 	// create an EOTS manager
 	eotsHomeDir := filepath.Join(t.TempDir(), "eots-home")
@@ -78,7 +78,7 @@ func startFinalityProviderAppWithRegisteredFp(t *testing.T, r *rand.Rand, cc cli
 	fpCfg.PollerConfig.StaticChainScanningStartHeight = startingHeight
 	fpdb, err := fpCfg.DatabaseConfig.GetDbBackend()
 	require.NoError(t, err)
-	app, err := service.NewFinalityProviderApp(&fpCfg, cc, ccc, em, fpdb, logger)
+	app, err := service.NewFinalityProviderApp(&fpCfg, cc, consumerCon, em, fpdb, logger)
 	require.NoError(t, err)
 	err = app.Start()
 	require.NoError(t, err)
@@ -95,7 +95,7 @@ func startFinalityProviderAppWithRegisteredFp(t *testing.T, r *rand.Rand, cc cli
 
 	// TODO: use mock metrics
 	m := metrics.NewFpMetrics()
-	fpIns, err := service.NewFinalityProviderInstance(fp.GetBIP340BTCPK(), &fpCfg, app.GetFinalityProviderStore(), cc, ccc, em, m, passphrase, make(chan *service.CriticalError), logger)
+	fpIns, err := service.NewFinalityProviderInstance(fp.GetBIP340BTCPK(), &fpCfg, app.GetFinalityProviderStore(), cc, consumerCon, em, m, passphrase, make(chan *service.CriticalError), logger)
 	require.NoError(t, err)
 
 	cleanUp := func() {

--- a/finality-provider/service/fp_manager.go
+++ b/finality-provider/service/fp_manager.go
@@ -45,6 +45,7 @@ type FinalityProviderManager struct {
 	fps    *store.FinalityProviderStore
 	config *fpcfg.Config
 	cc     clientcontroller.ClientController
+	ccc    clientcontroller.ConsumerClientController
 	em     eotsmanager.EOTSManager
 	logger *zap.Logger
 
@@ -59,6 +60,7 @@ func NewFinalityProviderManager(
 	fps *store.FinalityProviderStore,
 	config *fpcfg.Config,
 	cc clientcontroller.ClientController,
+	ccc clientcontroller.ConsumerClientController,
 	em eotsmanager.EOTSManager,
 	metrics *metrics.FpMetrics,
 	logger *zap.Logger,
@@ -70,6 +72,7 @@ func NewFinalityProviderManager(
 		fps:             fps,
 		config:          config,
 		cc:              cc,
+		ccc:             ccc,
 		em:              em,
 		metrics:         metrics,
 		logger:          logger,
@@ -389,7 +392,7 @@ func (fpm *FinalityProviderManager) addFinalityProviderInstance(
 		return fmt.Errorf("finality-provider instance already exists")
 	}
 
-	fpIns, err := NewFinalityProviderInstance(pk, fpm.config, fpm.fps, fpm.cc, fpm.em, fpm.metrics, passphrase, fpm.criticalErrChan, fpm.logger)
+	fpIns, err := NewFinalityProviderInstance(pk, fpm.config, fpm.fps, fpm.cc, fpm.ccc, fpm.em, fpm.metrics, passphrase, fpm.criticalErrChan, fpm.logger)
 	if err != nil {
 		return fmt.Errorf("failed to create finality-provider %s instance: %w", pkHex, err)
 	}
@@ -411,7 +414,7 @@ func (fpm *FinalityProviderManager) getLatestBlockWithRetry() (*types.BlockInfo,
 	)
 
 	if err := retry.Do(func() error {
-		latestBlock, err = fpm.cc.QueryBestBlock()
+		latestBlock, err = fpm.ccc.QueryBestBlock()
 		if err != nil {
 			return err
 		}

--- a/finality-provider/service/fp_manager_test.go
+++ b/finality-provider/service/fp_manager_test.go
@@ -93,7 +93,7 @@ func waitForStatus(t *testing.T, fpIns *service.FinalityProviderInstance, s prot
 		}, eventuallyWaitTimeOut, eventuallyPollTime)
 }
 
-func newFinalityProviderManagerWithRegisteredFp(t *testing.T, r *rand.Rand, cc clientcontroller.ClientController, ccc clientcontroller.ConsumerClientController) (*service.FinalityProviderManager, *bbntypes.BIP340PubKey, func()) {
+func newFinalityProviderManagerWithRegisteredFp(t *testing.T, r *rand.Rand, cc clientcontroller.ClientController, consumerCon clientcontroller.ConsumerController) (*service.FinalityProviderManager, *bbntypes.BIP340PubKey, func()) {
 	logger := zap.NewNop()
 	// create an EOTS manager
 	eotsHomeDir := filepath.Join(t.TempDir(), "eots-home")
@@ -123,7 +123,7 @@ func newFinalityProviderManagerWithRegisteredFp(t *testing.T, r *rand.Rand, cc c
 	require.NoError(t, err)
 
 	metricsCollectors := metrics.NewFpMetrics()
-	vm, err := service.NewFinalityProviderManager(fpStore, &fpCfg, cc, ccc, em, metricsCollectors, logger)
+	vm, err := service.NewFinalityProviderManager(fpStore, &fpCfg, cc, consumerCon, em, metricsCollectors, logger)
 	require.NoError(t, err)
 
 	// create registered finality-provider

--- a/finality-provider/service/fp_manager_test.go
+++ b/finality-provider/service/fp_manager_test.go
@@ -42,7 +42,7 @@ func FuzzStatusUpdate(f *testing.F) {
 
 		ctl := gomock.NewController(t)
 		mockClientController := mocks.NewMockClientController(ctl)
-		vm, fpPk, cleanUp := newFinalityProviderManagerWithRegisteredFp(t, r, mockClientController)
+		vm, fpPk, cleanUp := newFinalityProviderManagerWithRegisteredFp(t, r, mockClientController, mockClientController)
 		defer cleanUp()
 
 		// setup mocks
@@ -93,7 +93,7 @@ func waitForStatus(t *testing.T, fpIns *service.FinalityProviderInstance, s prot
 		}, eventuallyWaitTimeOut, eventuallyPollTime)
 }
 
-func newFinalityProviderManagerWithRegisteredFp(t *testing.T, r *rand.Rand, cc clientcontroller.ClientController) (*service.FinalityProviderManager, *bbntypes.BIP340PubKey, func()) {
+func newFinalityProviderManagerWithRegisteredFp(t *testing.T, r *rand.Rand, cc clientcontroller.ClientController, ccc clientcontroller.ConsumerClientController) (*service.FinalityProviderManager, *bbntypes.BIP340PubKey, func()) {
 	logger := zap.NewNop()
 	// create an EOTS manager
 	eotsHomeDir := filepath.Join(t.TempDir(), "eots-home")
@@ -123,7 +123,7 @@ func newFinalityProviderManagerWithRegisteredFp(t *testing.T, r *rand.Rand, cc c
 	require.NoError(t, err)
 
 	metricsCollectors := metrics.NewFpMetrics()
-	vm, err := service.NewFinalityProviderManager(fpStore, &fpCfg, cc, em, metricsCollectors, logger)
+	vm, err := service.NewFinalityProviderManager(fpStore, &fpCfg, cc, ccc, em, metricsCollectors, logger)
 	require.NoError(t, err)
 
 	// create registered finality-provider

--- a/itest/e2e_test.go
+++ b/itest/e2e_test.go
@@ -181,7 +181,7 @@ func TestFastSync(t *testing.T) {
 	t.Logf("the latest finalized block is at %v", finalizedHeight)
 
 	// check if the fast sync works by checking if the gap is not more than 1
-	currentHeaderRes, err := tm.BBNClient.QueryBestBlock()
+	currentHeaderRes, err := tm.BBNConsumerClient.QueryBestBlock()
 	currentHeight := currentHeaderRes.Height
 	t.Logf("the current block is at %v", currentHeight)
 	require.NoError(t, err)

--- a/itest/test_manager.go
+++ b/itest/test_manager.go
@@ -131,6 +131,7 @@ func StartManager(t *testing.T) *TestManager {
 		Fpa:               fpApp,
 		EOTSClient:        eotsCli,
 		BBNClient:         bc,
+		BBNConsumerClient: bcc,
 		CovenantPrivKeys:  covenantPrivKeys,
 		baseDir:           testDir,
 	}

--- a/itest/test_manager.go
+++ b/itest/test_manager.go
@@ -62,7 +62,7 @@ type TestManager struct {
 	Fpa               *service.FinalityProviderApp
 	EOTSClient        *client.EOTSManagerGRpcClient
 	BBNClient         *fpcc.BabylonController
-	BBCClient         *fpcc.BabylonConsumerController
+	BBNConsumerClient *fpcc.BabylonConsumerController
 	StakingParams     *types.StakingParams
 	CovenantPrivKeys  []*btcec.PrivateKey
 	baseDir           string
@@ -316,7 +316,7 @@ func (tm *TestManager) CheckBlockFinalization(t *testing.T, height uint64, num i
 
 	// as the votes have been collected, the block should be finalized
 	require.Eventually(t, func() bool {
-		b, err := tm.BBCClient.QueryBlock(height)
+		b, err := tm.BBNConsumerClient.QueryBlock(height)
 		if err != nil {
 			t.Logf("failed to query block at height %v: %s", height, err.Error())
 			return false
@@ -345,7 +345,7 @@ func (tm *TestManager) WaitForNFinalizedBlocks(t *testing.T, n int) []*types.Blo
 		err    error
 	)
 	require.Eventually(t, func() bool {
-		blocks, err = tm.BBCClient.QueryLatestFinalizedBlocks(uint64(n))
+		blocks, err = tm.BBNConsumerClient.QueryLatestFinalizedBlocks(uint64(n))
 		if err != nil {
 			t.Logf("failed to get the latest finalized block: %s", err.Error())
 			return false
@@ -368,13 +368,13 @@ func (tm *TestManager) WaitForFpShutDown(t *testing.T, pk *bbntypes.BIP340PubKey
 }
 
 func (tm *TestManager) StopAndRestartFpAfterNBlocks(t *testing.T, n int, fpIns *service.FinalityProviderInstance) {
-	blockBeforeStop, err := tm.BBCClient.QueryBestBlock()
+	blockBeforeStop, err := tm.BBNConsumerClient.QueryBestBlock()
 	require.NoError(t, err)
 	err = fpIns.Stop()
 	require.NoError(t, err)
 
 	require.Eventually(t, func() bool {
-		headerAfterStop, err := tm.BBCClient.QueryBestBlock()
+		headerAfterStop, err := tm.BBNConsumerClient.QueryBestBlock()
 		if err != nil {
 			return false
 		}


### PR DESCRIPTION
## Summary

To support the EVM chain and keep Babylon as the staking hub, we need to split `ClientController` into two parts.

* `ClientController` includes the functions for the Babylon hub:
   * `RegisterFinalityProvider`
   * `QueryFinalityProviderVotingPower`
   * `QueryLastFinalizedEpoch`
   * ...
* `ConsumerController` includes the functions for the Consumer chain:
  *  `SubmitFinalitySig`
  * `QueryFinalityProviderVotingPower`
  * `QueryBlock`
  * ...

## Test

`make test `

```bash                                          
go test ./...

ok      github.com/babylonchain/finality-provider/clientcontroller      2.022s

ok      github.com/babylonchain/finality-provider/eotsmanager   7.521s
ok      github.com/babylonchain/finality-provider/eotsmanager/cmd/eotsd/daemon  6.552s
ok      github.com/babylonchain/finality-provider/eotsmanager/store     3.647s

ok      github.com/babylonchain/finality-provider/finality-provider/service     22.624s
ok      github.com/babylonchain/finality-provider/finality-provider/store       5.580s
ok      github.com/babylonchain/finality-provider/keyring       7.576s
```