### PR TITLE
Add keyring-backend option to sign-schnorr command in eots.md

### DIFF
--- a/docs/eots.md
+++ b/docs/eots.md
@@ -131,7 +131,7 @@ given `key-name` or `btc-pk`. If both flags `--key-name` and `--btc-pk` are
 provided, `btc-pk` takes priority.
 
 ```shell
-eotsd sign-schnorr /path/to/data/file --home /path/to/eotsd/home/ --key-name my-key-name
+eotsd sign-schnorr /path/to/data/file --home /path/to/eotsd/home/ --key-name my-key-name --keyring-backend file
 {
   "key_name": "my-key-name",
   "pub_key_hex": "50b106208c921b5e8a1c45494306fe1fc2cf68f33b8996420867dc7667fde383",


### PR DESCRIPTION
This commit updates the eots.md documentation to include the --keyring-backend file option in the eotsd sign-schnorr command example. This addition ensures that the command specifies the use of the file-based keyring backend for managing keys.

Changes:
- Added --keyring-backend file option to the eotsd sign-schnorr command example.

This enhancement improves clarity and accuracy in the documentation, ensuring users are aware of the necessary flag to specify the keyring backend.
