### PR TITLE
`QueryLatestFinalizedBlocks(count uint64)` -> `QueryLatestFinalizedBlock()`

### DIFF
--- a/clientcontroller/babylon_consumer.go
+++ b/clientcontroller/babylon_consumer.go
@@ -166,8 +166,9 @@ func (bc *BabylonConsumerController) QueryFinalityProviderVotingPower(fpPk *btce
 	return res.VotingPower, nil
 }
 
-func (bc *BabylonConsumerController) QueryLatestFinalizedBlocks(count uint64) ([]*types.BlockInfo, error) {
-	return bc.queryLatestBlocks(nil, count, finalitytypes.QueriedBlockStatus_FINALIZED, true)
+func (bc *BabylonConsumerController) QueryLatestFinalizedBlock() (*types.BlockInfo, error) {
+	blocks, err := bc.queryLatestBlocks(nil, 1, finalitytypes.QueriedBlockStatus_FINALIZED, true)
+	return blocks[0], err
 }
 
 func (bc *BabylonConsumerController) QueryBlocks(startHeight, endHeight, limit uint64) ([]*types.BlockInfo, error) {

--- a/clientcontroller/evm_consumer.go
+++ b/clientcontroller/evm_consumer.go
@@ -80,8 +80,11 @@ func (ec *EVMConsumerController) QueryFinalityProviderVotingPower(fpPk *btcec.Pu
 	return 0, nil
 }
 
-func (ec *EVMConsumerController) QueryLatestFinalizedBlocks(count uint64) ([]*types.BlockInfo, error) {
-	return ec.queryLatestBlocks(nil, count, finalitytypes.QueriedBlockStatus_FINALIZED, true)
+func (ec *EVMConsumerController) QueryLatestFinalizedBlock() (*types.BlockInfo, error) {
+	return &types.BlockInfo{
+		Height: 0,
+		Hash:   nil,
+	}, nil
 }
 
 func (ec *EVMConsumerController) QueryBlocks(startHeight, endHeight, limit uint64) ([]*types.BlockInfo, error) {

--- a/clientcontroller/interface.go
+++ b/clientcontroller/interface.go
@@ -64,8 +64,8 @@ type ConsumerController interface {
 	// QueryFinalityProviderVotingPower queries the voting power of the finality provider at a given height
 	QueryFinalityProviderVotingPower(fpPk *btcec.PublicKey, blockHeight uint64) (uint64, error)
 
-	// QueryLatestFinalizedBlocks returns the latest finalized blocks
-	QueryLatestFinalizedBlocks(count uint64) ([]*types.BlockInfo, error)
+	// QueryLatestFinalizedBlock returns the latest finalized block
+	QueryLatestFinalizedBlock() (*types.BlockInfo, error)
 
 	// QueryBlock queries the block at the given height
 	QueryBlock(height uint64) (*types.BlockInfo, error)

--- a/finality-provider/service/app_test.go
+++ b/finality-provider/service/app_test.go
@@ -49,7 +49,7 @@ func FuzzRegisterFinalityProvider(f *testing.F) {
 		randomStartingHeight := uint64(r.Int63n(100) + 1)
 		currentHeight := randomStartingHeight + uint64(r.Int63n(10)+2)
 		mockConsumerController := testutil.PrepareMockedConsumerController(t, r, randomStartingHeight, currentHeight)
-		mockConsumerController.EXPECT().QueryLatestFinalizedBlocks(gomock.Any()).Return(nil, nil).AnyTimes()
+		mockConsumerController.EXPECT().QueryLatestFinalizedBlock().Return(nil, nil).AnyTimes()
 		mockConsumerController.EXPECT().QueryFinalityProviderVotingPower(gomock.Any(),
 			gomock.Any()).Return(uint64(0), nil).AnyTimes()
 		mockBabylonController := testutil.PrepareMockedBabylonController(t, uint64(0))

--- a/finality-provider/service/fastsync_test.go
+++ b/finality-provider/service/fastsync_test.go
@@ -36,7 +36,7 @@ func FuzzFastSync(f *testing.F) {
 		catchUpBlocks := testutil.GenBlocks(r, finalizedHeight+1, currentHeight)
 		expectedTxHash := testutil.GenRandomHexStr(r, 32)
 		finalizedBlock := &types.BlockInfo{Height: finalizedHeight, Hash: testutil.GenRandomByteArray(r, 32)}
-		mockConsumerController.EXPECT().QueryLatestFinalizedBlocks(uint64(1)).Return([]*types.BlockInfo{finalizedBlock}, nil).AnyTimes()
+		mockConsumerController.EXPECT().QueryLatestFinalizedBlock().Return(finalizedBlock, nil).AnyTimes()
 		mockConsumerController.EXPECT().QueryBlocks(finalizedHeight+1, currentHeight, uint64(10)).
 			Return(catchUpBlocks, nil)
 		mockConsumerController.EXPECT().SubmitBatchFinalitySigs(fpIns.GetBtcPk(), catchUpBlocks, gomock.Any()).

--- a/finality-provider/service/fp_instance.go
+++ b/finality-provider/service/fp_instance.go
@@ -325,11 +325,11 @@ func (fp *FinalityProviderInstance) tryFastSync(targetBlockHeight uint64) (*Fast
 	}
 
 	// get the last finalized height
-	lastFinalizedBlocks, err := fp.consumerCon.QueryLatestFinalizedBlocks(1)
+	lastFinalizedBlock, err := fp.consumerCon.QueryLatestFinalizedBlock()
 	if err != nil {
 		return nil, err
 	}
-	if lastFinalizedBlocks == nil {
+	if lastFinalizedBlock == nil {
 		fp.logger.Debug(
 			"no finalized blocks yet, no need to catch up",
 			zap.String("pk", fp.GetBtcPkHex()),
@@ -338,7 +338,7 @@ func (fp *FinalityProviderInstance) tryFastSync(targetBlockHeight uint64) (*Fast
 		return nil, nil
 	}
 
-	lastFinalizedHeight := lastFinalizedBlocks[0].Height
+	lastFinalizedHeight := lastFinalizedBlock.Height
 	lastProcessedHeight := fp.GetLastProcessedHeight()
 
 	// get the startHeight from the maximum of the lastVotedHeight and
@@ -584,13 +584,13 @@ func (fp *FinalityProviderInstance) getPollerStartingHeight() (uint64, error) {
 	//	(2) The finality providers do not submit signatures for any already
 	//	 finalised blocks.
 	initialBlockToGet := fp.GetLastProcessedHeight()
-	latestFinalisedBlock, err := fp.latestFinalizedBlocksWithRetry(1)
+	latestFinalisedBlock, err := fp.latestFinalizedBlockWithRetry()
 	if err != nil {
 		return 0, err
 	}
-	if len(latestFinalisedBlock) != 0 {
-		if latestFinalisedBlock[0].Height > initialBlockToGet {
-			initialBlockToGet = latestFinalisedBlock[0].Height
+	if latestFinalisedBlock != nil {
+		if latestFinalisedBlock.Height > initialBlockToGet {
+			initialBlockToGet = latestFinalisedBlock.Height
 		}
 	}
 
@@ -601,10 +601,10 @@ func (fp *FinalityProviderInstance) getPollerStartingHeight() (uint64, error) {
 	return initialBlockToGet, nil
 }
 
-func (fp *FinalityProviderInstance) latestFinalizedBlocksWithRetry(count uint64) ([]*types.BlockInfo, error) {
-	var response []*types.BlockInfo
+func (fp *FinalityProviderInstance) latestFinalizedBlockWithRetry() (*types.BlockInfo, error) {
+	var response *types.BlockInfo
 	if err := retry.Do(func() error {
-		latestFinalisedBlock, err := fp.consumerCon.QueryLatestFinalizedBlocks(count)
+		latestFinalisedBlock, err := fp.consumerCon.QueryLatestFinalizedBlock()
 		if err != nil {
 			return err
 		}

--- a/finality-provider/service/fp_manager_test.go
+++ b/finality-provider/service/fp_manager_test.go
@@ -53,7 +53,7 @@ func FuzzStatusUpdate(f *testing.F) {
 			Hash:   datagen.GenRandomByteArray(r, 32),
 		}
 		mockConsumerController.EXPECT().Close().Return(nil).AnyTimes()
-		mockConsumerController.EXPECT().QueryLatestFinalizedBlocks(gomock.Any()).Return(nil, nil).AnyTimes()
+		mockConsumerController.EXPECT().QueryLatestFinalizedBlock().Return(nil, nil).AnyTimes()
 		mockConsumerController.EXPECT().QueryLatestBlockHeight().Return(currentHeight, nil).AnyTimes()
 		mockConsumerController.EXPECT().QueryActivatedHeight().Return(uint64(1), nil).AnyTimes()
 		mockConsumerController.EXPECT().QueryBlock(gomock.Any()).Return(currentBlockRes, nil).AnyTimes()

--- a/itest/test_manager.go
+++ b/itest/test_manager.go
@@ -340,23 +340,23 @@ func (tm *TestManager) WaitForFpVoteCast(t *testing.T, fpIns *service.FinalityPr
 	return lastVotedHeight
 }
 
-func (tm *TestManager) WaitForNFinalizedBlocks(t *testing.T, n int) []*types.BlockInfo {
+func (tm *TestManager) WaitForNFinalizedBlocks(t *testing.T, n int) *types.BlockInfo {
 	var (
-		blocks []*types.BlockInfo
-		err    error
+		block *types.BlockInfo
+		err   error
 	)
 	require.Eventually(t, func() bool {
-		blocks, err = tm.BBNConsumerClient.QueryLatestFinalizedBlocks(uint64(n))
+		block, err = tm.BBNConsumerClient.QueryLatestFinalizedBlock()
 		if err != nil {
 			t.Logf("failed to get the latest finalized block: %s", err.Error())
 			return false
 		}
-		return len(blocks) == n
+		return true
 	}, eventuallyWaitTimeOut, eventuallyPollTime)
 
-	t.Logf("the block is finalized at %v", blocks[0].Height)
+	t.Logf("the block is finalized at %v", block.Height)
 
-	return blocks
+	return block
 }
 
 func (tm *TestManager) WaitForFpShutDown(t *testing.T, pk *bbntypes.BIP340PubKey) {

--- a/testutil/mocks/clientcontroller.go
+++ b/testutil/mocks/clientcontroller.go
@@ -223,19 +223,19 @@ func (mr *MockConsumerControllerMockRecorder) QueryLatestBlockHeight() *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryLatestBlockHeight", reflect.TypeOf((*MockConsumerController)(nil).QueryLatestBlockHeight))
 }
 
-// QueryLatestFinalizedBlocks mocks base method.
-func (m *MockConsumerController) QueryLatestFinalizedBlocks(count uint64) ([]*types.BlockInfo, error) {
+// QueryLatestFinalizedBlock mocks base method.
+func (m *MockConsumerController) QueryLatestFinalizedBlock() (*types.BlockInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "QueryLatestFinalizedBlocks", count)
-	ret0, _ := ret[0].([]*types.BlockInfo)
+	ret := m.ctrl.Call(m, "QueryLatestFinalizedBlock")
+	ret0, _ := ret[0].(*types.BlockInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// QueryLatestFinalizedBlocks indicates an expected call of QueryLatestFinalizedBlocks.
-func (mr *MockConsumerControllerMockRecorder) QueryLatestFinalizedBlocks(count interface{}) *gomock.Call {
+// QueryLatestFinalizedBlock indicates an expected call of QueryLatestFinalizedBlock.
+func (mr *MockConsumerControllerMockRecorder) QueryLatestFinalizedBlock() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryLatestFinalizedBlocks", reflect.TypeOf((*MockConsumerController)(nil).QueryLatestFinalizedBlocks), count)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryLatestFinalizedBlock", reflect.TypeOf((*MockConsumerController)(nil).QueryLatestFinalizedBlock))
 }
 
 // SubmitBatchFinalitySigs mocks base method.


### PR DESCRIPTION
## Summary

this changes `QueryLatestFinalizedBlocks(count uint64)` to `QueryLatestFinalizedBlock()`

after analyzing, it's only used in `latestFinalizedBlocksWithRetry()` and it's just checking 1 block. i.e. `QueryLatestFinalizedBlocks(1)`

I also don't see we need to get N latest finalized block in the near future.

so to make our life easier when we implement the interface function for evm_consumer, i am first making this change


## Test Plan

```
make mock-gen
make test
```