### PR TITLE
fix: fix lint/e2e error

### DIFF
--- a/eotsmanager/client/rpcclient.go
+++ b/eotsmanager/client/rpcclient.go
@@ -22,7 +22,7 @@ type EOTSManagerGRpcClient struct {
 }
 
 func NewEOTSManagerGRpcClient(remoteAddr string) (*EOTSManagerGRpcClient, error) {
-	conn, err := grpc.Dial(remoteAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(remoteAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return nil, fmt.Errorf("failed to build gRPC connection to %s: %w", remoteAddr, err)
 	}

--- a/finality-provider/service/client/rpcclient.go
+++ b/finality-provider/service/client/rpcclient.go
@@ -18,7 +18,7 @@ type FinalityProviderServiceGRpcClient struct {
 }
 
 func NewFinalityProviderServiceGRpcClient(remoteAddr string) (*FinalityProviderServiceGRpcClient, func(), error) {
-	conn, err := grpc.Dial(remoteAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(remoteAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to build gRPC connection to %s: %w", remoteAddr, err)
 	}

--- a/itest/e2e_test.go
+++ b/itest/e2e_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/babylonchain/finality-provider/finality-provider/proto"
-	"github.com/babylonchain/finality-provider/finality-provider/service"
 	"github.com/babylonchain/finality-provider/types"
 )
 
@@ -122,17 +121,12 @@ func TestMultipleFinalityProviders(t *testing.T) {
 	defer tm.Stop(t)
 
 	// submit BTC delegations for each finality-provider
-	for _, fpIns := range fpInstances {
-		tm.Wg.Add(1)
-		go func(fpi *service.FinalityProviderInstance) {
-			defer tm.Wg.Done()
-			// check the public randomness is committed
-			tm.WaitForFpPubRandCommitted(t, fpi)
-			// send a BTC delegation
-			_ = tm.InsertBTCDelegation(t, []*btcec.PublicKey{fpi.GetBtcPk()}, stakingTime, stakingAmount)
-		}(fpIns)
+	for _, fpi := range fpInstances {
+		// check the public randomness is committed
+		tm.WaitForFpPubRandCommitted(t, fpi)
+		// send a BTC delegation
+		_ = tm.InsertBTCDelegation(t, []*btcec.PublicKey{fpi.GetBtcPk()}, stakingTime, stakingAmount)
 	}
-	tm.Wg.Wait()
 
 	// check the BTC delegations are pending
 	delsResp := tm.WaitForNPendingDels(t, n)


### PR DESCRIPTION
Grpc/Protobuf dependencies were bumped in this commit
https://github.com/babylonchain/finality-provider/commit/b79ac3101a2ef8205b97a7d1a8a061fff792d03f#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R34-R35
due to which grps.Dial has become deprecated and causes lint failure. This pr replaces deprecated with grpc.NewClient


```
// Dial calls DialContext(context.Background(), target, opts...).
//
// Deprecated: use NewClient instead.  Will be supported throughout 1.x.
func Dial(target string, opts ...DialOption) (*ClientConn, error) {
	return DialContext(context.Background(), target, opts...)
}
```

Lint doesn't fail in dev branch as it still uses old version of grpc
