### PR TITLE
chore: Fix issues in retry loops

### DIFF
--- a/finality-provider/service/errors.go
+++ b/finality-provider/service/errors.go
@@ -1,0 +1,7 @@
+package service
+
+import "errors"
+
+var (
+	ErrFinalityProviderShutDown = errors.New("the finality provider instance is shutting down")
+)

--- a/finality-provider/service/fp_instance.go
+++ b/finality-provider/service/fp_instance.go
@@ -218,6 +218,7 @@ func (fp *FinalityProviderInstance) finalitySigSubmissionLoop() {
 			}
 			// the block is finalized, no need to submit finality signature
 			if isFinalized {
+				fp.MustSetLastProcessedHeight(b.Height)
 				continue
 			}
 

--- a/log/log.go
+++ b/log/log.go
@@ -63,7 +63,7 @@ func NewRootLoggerWithFile(logFile string, level string) (*zap.Logger, error) {
 	if err := util.MakeDirectory(filepath.Dir(logFile)); err != nil {
 		return nil, err
 	}
-	f, err := os.OpenFile(logFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
+	f, err := os.OpenFile(logFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0660)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR fixed two issues #371 and #372  related to the retry loops:
* `retryCheckRandomnessUntilBlockFinalized ` can be returned if the block is finalized but the randomness does not exist. In this case, we should skip this block for submitting a finality vote. Otherwise, the submission will fail with `ErrPubRandNotExist`. The PR fixed this issue by introducing a `bool` indicating whether the target block is finalized or not.
* within the `retryCheckRandomnessUntilBlockFinalized` loop, if the randomness is never submitted, the loop will stall because the maximum retry time is only applied in errors. This PR addressed this by also limiting the time of retries if the randomness does not exist.

This PR also added an error type `ErrFinalityProviderShutDown` to close the retry loops gracefully upon shutdown.