### PR TITLE
Fix typos

### DIFF
--- a/clientcontroller/babylon.go
+++ b/clientcontroller/babylon.go
@@ -76,7 +76,7 @@ func (bc *BabylonController) mustGetTxSigner() string {
 
 func (bc *BabylonController) GetKeyAddress() sdk.AccAddress {
 	// get key address, retrieves address based on key name which is configured in
-	// cfg *stakercfg.BBNConfig. If this fails, it means we have misconfiguration problem
+	// cfg *stakercfg.BBNConfig. If this fails, it means we have a misconfiguration problem
 	// and we should panic.
 	// This is checked at the start of BabylonController, so if it fails something is really wrong
 

--- a/clientcontroller/retry_utils.go
+++ b/clientcontroller/retry_utils.go
@@ -9,7 +9,7 @@ import (
 	finalitytypes "github.com/babylonchain/babylon/x/finality/types"
 )
 
-// these errors are considered unrecoverable because these indicate
+// these errors are considered unrecoverable because they indicate
 // something critical in the finality provider program or the consumer chain
 var unrecoverableErrors = []*sdkErr.Error{
 	finalitytypes.ErrBlockNotFound,

--- a/docs/eots.md
+++ b/docs/eots.md
@@ -9,7 +9,7 @@ using them to produce EOTS signatures.
 in
 the [Babylon BTC Staking Litepaper](https://docs.babylonchain.io/assets/files/btc_staking_litepaper-32bfea0c243773f0bfac63e148387aef.pdf).
 In short, the EOTS manager produces EOTS public/private randomness pairs. The
-finality provider commits the public part of this pairs to Babylon for every future
+finality provider commits the public part of these pairs to Babylon for every future
 block height that they intend to provide a finality signature for. If the finality
 provider votes for two different blocks on the same height, they will have to reuse
 the same private randomness which will lead to their underlying private key being

--- a/docs/finality-provider.md
+++ b/docs/finality-provider.md
@@ -51,7 +51,7 @@ For different operating systems, those are:
 Below are some important parameters of the `fpd.conf` file.
 
 **Note**:
-The configuration below requires to point to the path where this keyring is
+The configuration below requires pointing to the path where this keyring is
 stored `KeyDirectory`. This `Key` field stores the key name used for interacting with
 the consumer chain and will be specified along with the
 `KeyringBackend` field in the next [step](#3-add-key-for-the-consumer-chain). So we

--- a/eotsmanager/eotsmanager.go
+++ b/eotsmanager/eotsmanager.go
@@ -26,7 +26,7 @@ type EOTSManager interface {
 	KeyRecord(uid []byte, passphrase string) (*types.KeyRecord, error)
 
 	// SignEOTS signs an EOTS using the private key of the finality provider and the corresponding
-	// secret randomness of the give chain at the given height
+	// secret randomness of the given chain at the given height
 	// It fails if the finality provider does not exist or there's no randomness committed to the given height
 	// or passPhrase is incorrect
 	SignEOTS(uid []byte, chainID []byte, msg []byte, height uint64, passphrase string) (*btcec.ModNScalar, error)

--- a/eotsmanager/localmanager.go
+++ b/eotsmanager/localmanager.go
@@ -164,7 +164,7 @@ func loadBIP340PubKeyFromKeyringRecord(record *keyring.Record) (*bbntypes.BIP340
 // TODO the current implementation is a PoC, which does not contain any anti-slasher mechanism
 //
 //	a simple anti-slasher mechanism could be that the manager remembers the tuple (fpPk, chainID, height) or
-//	the hash of each generated randomness and return error if the same randomness is requested tweice
+//	the hash of each generated randomness and return error if the same randomness is requested twice
 func (lm *LocalEOTSManager) CreateRandomnessPairList(fpPk []byte, chainID []byte, startHeight uint64, num uint32, passphrase string) ([]*btcec.FieldVal, error) {
 	prList := make([]*btcec.FieldVal, 0, num)
 

--- a/itest/e2e_test.go
+++ b/itest/e2e_test.go
@@ -149,7 +149,7 @@ func TestMultipleFinalityProviders(t *testing.T) {
 	// check the BTC delegations are active
 	_ = tm.WaitForNActiveDels(t, n)
 
-	// check there's a block finalized
+	// check if there's a block finalized
 	_ = tm.WaitForNFinalizedBlocks(t, 1)
 }
 


### PR DESCRIPTION
This PR addresses several typographical errors across various files in the project. The changes improve readability and maintain the professional standard of the documentation and code comments.

Hope it helps
Best regards, Elias.