### PR TITLE
refactor: remove unused config in wasmd client

### DIFF
--- a/cosmwasmclient/query/client.go
+++ b/cosmwasmclient/query/client.go
@@ -3,16 +3,11 @@ package query
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"time"
-
-	"github.com/cosmos/cosmos-sdk/types/query"
 
 	"github.com/babylonchain/finality-provider/cosmwasmclient/config"
 	rpcclient "github.com/cometbft/cometbft/rpc/client"
 	"github.com/cosmos/cosmos-sdk/client"
-	grpctypes "github.com/cosmos/cosmos-sdk/types/grpc"
-	"google.golang.org/grpc/metadata"
 )
 
 // QueryClient is a client that can only perform queries to a Babylon node
@@ -67,29 +62,9 @@ func (c *QueryClient) IsRunning() bool {
 	return c.RPCClient.IsRunning()
 }
 
-// getQueryContext returns a context that includes the height and uses the timeout from the config
+// getQueryContext returns a context that uses the timeout from the config
 // (adapted from https://github.com/strangelove-ventures/lens/blob/v0.5.4/client/query/query_options.go#L29-L36)
 func (c *QueryClient) getQueryContext() (context.Context, context.CancelFunc) {
-	defaultOptions := DefaultQueryOptions()
 	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
-	strHeight := strconv.Itoa(int(defaultOptions.Height))
-	ctx = metadata.AppendToOutgoingContext(ctx, grpctypes.GRPCBlockHeightHeader, strHeight)
 	return ctx, cancel
-}
-
-type QueryOptions struct {
-	Pagination *query.PageRequest
-	Height     int64
-}
-
-func DefaultQueryOptions() *QueryOptions {
-	return &QueryOptions{
-		Pagination: &query.PageRequest{
-			Key:        []byte(""),
-			Offset:     0,
-			Limit:      1000,
-			CountTotal: true,
-		},
-		Height: 0,
-	}
 }


### PR DESCRIPTION
## Summary

the code here adds `x-cosmos-block-height` metadata which is used to query historical data ([reference](https://docs.cosmos.network/main/user/run-node/interact-node#query-for-historical-state-using-grpcurl))

this is unnecessary and never used b/c it always passes 0 height

also `DefaultQueryOptions()` and `QueryOptions` are never used elsewhere (seems they are just dead code copied from [here](https://github.com/strangelove-ventures/lens/blob/v0.5.4/client/query/query_options.go))

## Test Plan

```
make test
make test-e2e
```