### PR TITLE
feat: the queries for OPStack L2 consumer

### DIFF
--- a/clientcontroller/opstackl2/consumer.go
+++ b/clientcontroller/opstackl2/consumer.go
@@ -225,7 +225,8 @@ func (cc *OPStackL2ConsumerController) QueryFinalityProviderVotingPower(fpPk *bt
 }
 
 // QueryLatestFinalizedBlock returns the finalized L2 block from a RPC call
-// TODO: return the BTC finalized L2 block, it is tricky
+// TODO: return the BTC finalized L2 block, it is tricky b/c it's not recorded anywhere so we can
+// use some exponential strategy to search
 func (cc *OPStackL2ConsumerController) QueryLatestFinalizedBlock() (*types.BlockInfo, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), cc.cfg.Timeout)
 	defer cancel()
@@ -244,6 +245,7 @@ func (cc *OPStackL2ConsumerController) QueryBlocks(startHeight, endHeight, limit
 	var blocks []*types.BlockInfo
 	var count uint64 = 0
 
+	// TODO(lester): add test
 	for height := startHeight; height <= endHeight && count < limit; height++ {
 		block, err := cc.QueryBlock(height)
 		if err != nil {

--- a/clientcontroller/opstackl2/consumer.go
+++ b/clientcontroller/opstackl2/consumer.go
@@ -81,21 +81,6 @@ func NewOPStackL2ConsumerController(
 	}, nil
 }
 
-func (cc *OPStackL2ConsumerController) ExecuteContract(payload []byte) (*provider.RelayerTxResponse, error) {
-	execMsg := &wasmtypes.MsgExecuteContract{
-		Sender:   cc.bbnClient.MustGetAddr(),
-		Contract: cc.cfg.OPFinalityGadgetAddress,
-		Msg:      payload,
-	}
-
-	res, err := cc.reliablySendMsg(execMsg, nil, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return res, nil
-}
-
 func (cc *OPStackL2ConsumerController) reliablySendMsg(msg sdk.Msg, expectedErrs []*sdkErr.Error, unrecoverableErrs []*sdkErr.Error) (*provider.RelayerTxResponse, error) {
 	return cc.reliablySendMsgs([]sdk.Msg{msg}, expectedErrs, unrecoverableErrs)
 }


### PR DESCRIPTION
## Summary

Implemented:
```Go
// QueryBlock queries the block at the given height
QueryBlock(height uint64) (*types.BlockInfo, error)

// QueryBlocks returns a list of blocks from startHeight to endHeight
QueryBlocks(startHeight, endHeight, limit uint64) ([]*types.BlockInfo, error)

// QueryLatestBlockHeight queries the tip block height of the consumer chain
QueryLatestBlockHeight() (uint64, error)

// QueryLatestFinalizedBlock returns the finalized L2 block from a RPC call
// TODO: return the BTC finalized L2 block, it is tricky
QueryLatestFinalizedBlock() (*types.BlockInfo, error)
```
TODO:
The `op-finality-gadget` contract needs support for the following queries.

- [ ] `QueryActivatedHeight`
```Go
// QueryActivatedHeight returns the activated height of the consumer chain
// error will be returned if the consumer chain has not been activated
QueryActivatedHeight() (uint64, error)
```
- [ ] `QueryFinalityProviderVotingPower`
```Go
// QueryFinalityProviderVotingPower queries the voting power of the finality provider at a given height
QueryFinalityProviderVotingPower(fpPk *btcec.PublicKey, blockHeight uint64) (uint64, error)
```
- [ ] `QueryLastCommittedPublicRand`
```Go
// QueryLastCommittedPublicRand returns the last committed public randomness
QueryLastCommittedPublicRand(fpPk *btcec.PublicKey, count uint64) (map[uint64]*finalitytypes.PubRandCommitResponse, error)
```
- [ ] `QueryIsBlockFinalized`
```Go
// QueryIsBlockFinalized queries if the block at the given height is finalized
QueryIsBlockFinalized(height uint64) (bool, error)
```


