### PR TITLE
hotfix: fix consumer ID

### DIFF
--- a/clientcontroller/babylon.go
+++ b/clientcontroller/babylon.go
@@ -118,6 +118,7 @@ func (bc *BabylonController) RegisterFinalityProvider(
 	commission *math.LegacyDec,
 	description []byte,
 	masterPubRand string,
+	consumerID string,
 ) (*types.TxResponse, uint64, error) {
 	var bbnPop btcstakingtypes.ProofOfPossession
 	if err := bbnPop.Unmarshal(pop); err != nil {
@@ -137,6 +138,7 @@ func (bc *BabylonController) RegisterFinalityProvider(
 		Commission:    commission,
 		Description:   &sdkDescription,
 		MasterPubRand: masterPubRand,
+		ConsumerId:    consumerID,
 	}
 
 	res, err := bc.reliablySendMsg(msg, emptyErrs, emptyErrs)

--- a/clientcontroller/interface.go
+++ b/clientcontroller/interface.go
@@ -27,6 +27,7 @@ type ClientController interface {
 		commission *math.LegacyDec,
 		description []byte,
 		masterPubRand string,
+		consumerID string,
 	) (*types.TxResponse, uint64, error)
 
 	// SubmitFinalitySig submits the finality signature to the consumer chain

--- a/finality-provider/service/app.go
+++ b/finality-provider/service/app.go
@@ -187,6 +187,7 @@ func (app *FinalityProviderApp) RegisterFinalityProvider(fpPkStr string) (*Regis
 		description:     fp.Description,
 		commission:      fp.Commission,
 		masterPubRand:   fp.MasterPubRand,
+		consumerID:      fp.ChainID,
 		errResponse:     make(chan error, 1),
 		successResponse: make(chan *RegisterFinalityProviderResponse, 1),
 	}
@@ -541,6 +542,7 @@ func (app *FinalityProviderApp) registrationLoop() {
 				req.commission,
 				desBytes,
 				req.masterPubRand,
+				req.consumerID,
 			)
 
 			if err != nil {

--- a/finality-provider/service/app_test.go
+++ b/finality-provider/service/app_test.go
@@ -106,6 +106,7 @@ func FuzzRegisterFinalityProvider(f *testing.F) {
 				testutil.ZeroCommissionRate(),
 				gomock.Any(),
 				fp.MasterPubRand,
+				"",
 			).Return(&types.TxResponse{TxHash: txHash}, uint64(0), nil).AnyTimes()
 
 		res, err := app.RegisterFinalityProvider(fp.GetBIP340BTCPK().MarshalHex())

--- a/finality-provider/service/app_test.go
+++ b/finality-provider/service/app_test.go
@@ -106,7 +106,7 @@ func FuzzRegisterFinalityProvider(f *testing.F) {
 				testutil.ZeroCommissionRate(),
 				gomock.Any(),
 				fp.MasterPubRand,
-				"",
+				fp.ChainID,
 			).Return(&types.TxResponse{TxHash: txHash}, uint64(0), nil).AnyTimes()
 
 		res, err := app.RegisterFinalityProvider(fp.GetBIP340BTCPK().MarshalHex())

--- a/finality-provider/service/types.go
+++ b/finality-provider/service/types.go
@@ -39,6 +39,7 @@ type registerFinalityProviderRequest struct {
 	description     *stakingtypes.Description
 	commission      *sdkmath.LegacyDec
 	masterPubRand   string
+	consumerID      string
 	errResponse     chan error
 	successResponse chan *RegisterFinalityProviderResponse
 }

--- a/testutil/mocks/babylon.go
+++ b/testutil/mocks/babylon.go
@@ -171,9 +171,9 @@ func (mr *MockClientControllerMockRecorder) QueryLatestFinalizedBlocks(count int
 }
 
 // RegisterFinalityProvider mocks base method.
-func (m *MockClientController) RegisterFinalityProvider(chainPk []byte, fpPk *btcec.PublicKey, pop []byte, commission *math.LegacyDec, description []byte, masterPubRand string) (*types.TxResponse, uint64, error) {
+func (m *MockClientController) RegisterFinalityProvider(chainPk []byte, fpPk *btcec.PublicKey, pop []byte, commission *math.LegacyDec, description []byte, masterPubRand, consumerID string) (*types.TxResponse, uint64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RegisterFinalityProvider", chainPk, fpPk, pop, commission, description, masterPubRand)
+	ret := m.ctrl.Call(m, "RegisterFinalityProvider", chainPk, fpPk, pop, commission, description, masterPubRand, consumerID)
 	ret0, _ := ret[0].(*types.TxResponse)
 	ret1, _ := ret[1].(uint64)
 	ret2, _ := ret[2].(error)
@@ -181,9 +181,9 @@ func (m *MockClientController) RegisterFinalityProvider(chainPk []byte, fpPk *bt
 }
 
 // RegisterFinalityProvider indicates an expected call of RegisterFinalityProvider.
-func (mr *MockClientControllerMockRecorder) RegisterFinalityProvider(chainPk, fpPk, pop, commission, description, masterPubRand interface{}) *gomock.Call {
+func (mr *MockClientControllerMockRecorder) RegisterFinalityProvider(chainPk, fpPk, pop, commission, description, masterPubRand, consumerID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterFinalityProvider", reflect.TypeOf((*MockClientController)(nil).RegisterFinalityProvider), chainPk, fpPk, pop, commission, description, masterPubRand)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterFinalityProvider", reflect.TypeOf((*MockClientController)(nil).RegisterFinalityProvider), chainPk, fpPk, pop, commission, description, masterPubRand, consumerID)
 }
 
 // SubmitBatchFinalitySigs mocks base method.


### PR DESCRIPTION
This PR fixes the bug in rc where the consumer ID is not passed to the finality provider registration request.

PoC: I registered a consumer FP using this version successfully.

![image](https://github.com/babylonchain/finality-provider/assets/9570153/a28c44e8-ea1a-4be6-b322-5a48153f2c7c)

```
➜  finality-provider git:(release-euphrates-0.2.0-rc.1) ✗ babylond query btcstaking finality-provider ae19288a43b107c332662bbdf2cd1c829a9baabbd1fd98af4559500514719cde --node https://rpc-euphrates.devnet.babylonchain.io:443
finality_provider:
  babylon_pk:
    key: A5Htl6J2F/XDdL/SiSSrDa9vJ5hfuJRKYueVaQWxIefB
  btc_pk: ae19288a43b107c332662bbdf2cd1c829a9baabbd1fd98af4559500514719cde
  commission: "0.050000000000000000"
  description:
    details: ""
    identity: ""
    moniker: test gaia fp
    security_contact: ""
    website: ""
  height: "0"
  master_pub_rand: xpub661MyMwAqRbcFJoYM84xqYTzkf8XqvL2VLsogx4BDveFMcTDoAeXUBZgjsootUjuxnrfYCcCtcY9RiGoFtcr5iJ8z7VuN24kQj4kXYFuhx2
  pop:
    babylon_sig: QveKPDiY6+VvOGsuEjiUY9/sP1NUSbwnEsECzqtAymgzNBljdxHtmgH9fYw2ZoI/Ku0J1ItraFDrdyXqY6s4hw==
    btc_sig: ucQFqu8fDcI/nabiNoKdBAM7f1GWQ62Aloe/0EXsXoD9LPngx0mj8jmDOSAkXuYsnzfrF7G5anvp8MY483fSDA==
    btc_sig_type: BIP340
  registered_epoch: "703"
  slashed_babylon_height: "0"
  slashed_btc_height: "0"
  voting_power: "0"
➜  finality-provider git:(release-euphrates-0.2.0-rc.1) ✗ babylond query btcstkconsumer finality-provider-consumer ae19288a43b107c332662bbdf2cd1c829a9baabbd1fd98af4559500514719cde --node https://rpc-euphrates.devnet.babylonchain.io:443
consumer_id: 07-tendermint-5
➜  finality-provider git:(release-euphrates-0.2.0-rc.1) ✗ babylond query btcstkconsumer finality-provider 07-tendermint-5 ae19288a43b107c332662bbdf2cd1c829a9baabbd1fd98af4559500514719cde --node https://rpc-euphrates.devnet.babylonchain.io:443
finality_provider:
  babylon_pk:
    key: A5Htl6J2F/XDdL/SiSSrDa9vJ5hfuJRKYueVaQWxIefB
  btc_pk: ae19288a43b107c332662bbdf2cd1c829a9baabbd1fd98af4559500514719cde
  commission: "0.050000000000000000"
  consumer_id: 07-tendermint-5
  description:
    details: ""
    identity: ""
    moniker: test gaia fp
    security_contact: ""
    website: ""
  height: "0"
  pop:
    babylon_sig: QveKPDiY6+VvOGsuEjiUY9/sP1NUSbwnEsECzqtAymgzNBljdxHtmgH9fYw2ZoI/Ku0J1ItraFDrdyXqY6s4hw==
    btc_sig: ucQFqu8fDcI/nabiNoKdBAM7f1GWQ62Aloe/0EXsXoD9LPngx0mj8jmDOSAkXuYsnzfrF7G5anvp8MY483fSDA==
    btc_sig_type: BIP340
  slashed_babylon_height: "0"
  slashed_btc_height: "0"
  voting_power: "0"
```