### PR TITLE
feat: queries for OPStack L2

### DIFF
--- a/clientcontroller/opstackl2/consumer.go
+++ b/clientcontroller/opstackl2/consumer.go
@@ -222,7 +222,7 @@ func (cc *OPStackL2ConsumerController) SubmitBatchFinalitySigs(
 // QueryFinalityProviderVotingPower queries the voting power of the finality provider at a given height.
 // This interface function only used for checking if the FP is eligible for submitting sigs.
 // Now we can simply hardcode the voting power to a positive value.
-// TODO: Another way is that FP leverages backend service that indexes voting power for Babylon.
+// TODO: see this issue https://github.com/babylonchain/finality-provider/issues/390 for more details
 func (cc *OPStackL2ConsumerController) QueryFinalityProviderVotingPower(fpPk *btcec.PublicKey, blockHeight uint64) (uint64, error) {
 	return 1, nil
 }

--- a/clientcontroller/opstackl2/msg.go
+++ b/clientcontroller/opstackl2/msg.go
@@ -40,12 +40,23 @@ type SubmitFinalitySignatureResponse struct {
 }
 
 type QueryMsg struct {
-	Config *Config `json:"config,omitempty"`
+	Config            *Config            `json:"config,omitempty"`
+	LastPubRandCommit *LastPubRandCommit `json:"last_pub_rand_commit,omitempty"`
 }
 
 type Config struct{}
 
+type LastPubRandCommit struct {
+	BtcPkHex string `json:"btc_pk_hex"`
+}
+
 type ConfigResponse struct {
 	ConsumerId      string `json:"consumer_id"`
 	ActivatedHeight uint64 `json:"activated_height"`
+}
+
+type LastPubRandCommitResponse struct {
+	StartHeight uint64 `json:"start_height"`
+	NumPubRand  uint64 `json:"num_pub_rand"`
+	Commitment  []byte `json:"commitment"`
 }


### PR DESCRIPTION
This PR implements these consumer queries of OPStack L2:
* QueryIsBlockFinalized
* QueryLastCommittedPublicRand
* QueryFinalityProviderVotingPower
