### PR TITLE
chore: fix nil pointer

### DIFF
--- a/clientcontroller/babylon/consumer.go
+++ b/clientcontroller/babylon/consumer.go
@@ -332,7 +332,10 @@ func (bc *BabylonConsumerController) QueryLatestBlockHeight() (uint64, error) {
 	if err != nil || len(blocks) != 1 {
 		// try query comet block if the index block query is not available
 		block, err := bc.queryCometBestBlock()
-		return block.Height, err
+		if err != nil {
+			return 0, err
+		}
+		return block.Height, nil
 	}
 
 	return blocks[0].Height, nil


### PR DESCRIPTION
When error occurs, `block` is `nil` and `block.Height` will cause a nil pointer panic. Uncovered in local deployment