### PR TITLE
chore: remove duplicate codes

### DIFF
--- a/itest/consumer_test_manager.go
+++ b/itest/consumer_test_manager.go
@@ -19,7 +19,6 @@ import (
 	cwcc "github.com/babylonchain/finality-provider/clientcontroller/cosmwasm"
 	"github.com/babylonchain/finality-provider/eotsmanager/client"
 	eotsconfig "github.com/babylonchain/finality-provider/eotsmanager/config"
-	"github.com/babylonchain/finality-provider/finality-provider/config"
 	fpcfg "github.com/babylonchain/finality-provider/finality-provider/config"
 	"github.com/babylonchain/finality-provider/finality-provider/service"
 	"github.com/babylonchain/finality-provider/types"
@@ -48,7 +47,7 @@ type ConsumerTestManager struct {
 
 func StartConsumerManager(t *testing.T) *ConsumerTestManager {
 	// Setup consumer test manager
-	testDir, err := tempDirWithName("fpe2etest")
+	testDir, err := baseDir("fpe2etest")
 	require.NoError(t, err)
 
 	logger := zap.NewNop()
@@ -71,7 +70,7 @@ func StartConsumerManager(t *testing.T) *ConsumerTestManager {
 	wh := NewWasmdNodeHandler(t)
 	err = wh.Start()
 	require.NoError(t, err)
-	cfg.CosmwasmConfig = config.DefaultCosmwasmConfig()
+	cfg.CosmwasmConfig = fpcfg.DefaultCosmwasmConfig()
 	cfg.CosmwasmConfig.KeyDirectory = wh.dataDir
 	// TODO: make random contract addresses for now to avoid validation errors
 	//  later in the e2e tests we would upload the contract and update the addresses

--- a/itest/test_manager.go
+++ b/itest/test_manager.go
@@ -83,7 +83,7 @@ type TestDelegationData struct {
 }
 
 func StartManager(t *testing.T) *TestManager {
-	testDir, err := tempDirWithName("fpe2etest")
+	testDir, err := baseDir("fpe2etest")
 	require.NoError(t, err)
 
 	logger := zap.NewNop()
@@ -681,23 +681,6 @@ func defaultFpConfig(keyringDir, homeDir string) *fpcfg.Config {
 	cfg.BabylonConfig.GasAdjustment = 20
 
 	return &cfg
-}
-
-func tempDirWithName(name string) (string, error) {
-	tempPath := os.TempDir()
-
-	tempName, err := os.MkdirTemp(tempPath, name)
-	if err != nil {
-		return "", err
-	}
-
-	err = os.Chmod(tempName, 0755)
-
-	if err != nil {
-		return "", err
-	}
-
-	return tempName, nil
 }
 
 func newDescription(moniker string) *stakingtypes.Description {


### PR DESCRIPTION
The function [baseDir](https://github.com/babylonchain/finality-provider/blob/base/consumer-chain-support/itest/utils.go#L5) is the same as [tempDirWithName](https://github.com/babylonchain/finality-provider/blob/base/consumer-chain-support/itest/test_manager.go#L686), this PR removes the duplicate codes.