### PR TITLE
fix: fast sync for consumer

### DIFF
--- a/finality-provider/service/fp_instance.go
+++ b/finality-provider/service/fp_instance.go
@@ -363,6 +363,20 @@ func (fp *FinalityProviderInstance) tryFastSync(targetBlockHeight uint64) (*Fast
 		return nil, fmt.Errorf("the finality-provider %s is already in sync", fp.GetBtcPkHex())
 	}
 
+	// get the activated height from the consumer controller
+	activatedHeight, err := fp.consumerCon.QueryActivatedHeight()
+	if err != nil {
+		return nil, err
+	}
+	if targetBlockHeight < activatedHeight {
+		fp.logger.Debug(
+			"finality gadget is not activated yet, no need to catch up",
+			zap.Uint64("activated height", activatedHeight),
+			zap.Uint64("target height", targetBlockHeight),
+		)
+		return nil, nil
+	}
+
 	// get the last finalized height
 	lastFinalizedBlock, err := fp.latestFinalizedBlockWithRetry()
 	if err != nil {

--- a/finality-provider/service/fp_instance.go
+++ b/finality-provider/service/fp_instance.go
@@ -370,7 +370,7 @@ func (fp *FinalityProviderInstance) tryFastSync(targetBlockHeight uint64) (*Fast
 	}
 	if targetBlockHeight < activatedHeight {
 		fp.logger.Debug(
-			"finality gadget is not activated yet, no need to catch up",
+			"finality provider is not activated yet on the consumer, no need to catch up",
 			zap.Uint64("activated height", activatedHeight),
 			zap.Uint64("target height", targetBlockHeight),
 		)


### PR DESCRIPTION
This PR fixes the error of fast sync for the consumer.
When the finality provider is not activated yet on the consumer, there is no need to catch up.
Also, we checked all where the function `tryFastSync` is called, and it would not block/break them when returning `nil`. 