### PR TITLE
fix: revert the pr #401 commit

### DIFF
--- a/finality-provider/service/fp_instance.go
+++ b/finality-provider/service/fp_instance.go
@@ -363,20 +363,6 @@ func (fp *FinalityProviderInstance) tryFastSync(targetBlockHeight uint64) (*Fast
 		return nil, fmt.Errorf("the finality-provider %s is already in sync", fp.GetBtcPkHex())
 	}
 
-	// get the activated height from the consumer controller
-	activatedHeight, err := fp.consumerCon.QueryActivatedHeight()
-	if err != nil {
-		return nil, err
-	}
-	if targetBlockHeight < activatedHeight {
-		fp.logger.Debug(
-			"finality provider is not activated yet on the consumer, no need to catch up",
-			zap.Uint64("activated height", activatedHeight),
-			zap.Uint64("target height", targetBlockHeight),
-		)
-		return nil, nil
-	}
-
 	// get the last finalized height
 	lastFinalizedBlock, err := fp.latestFinalizedBlockWithRetry()
 	if err != nil {


### PR DESCRIPTION
The PR reverts the commit of PR https://github.com/babylonchain/finality-provider/pull/401.
In Babylon, the BTC Staking protocol is activated means [there exists at least one active BTC delegation](https://github.com/babylonchain/babylon/tree/dev/x/btcstaking#beginblocker).
It would fail to query the activated height before the BTC delegation, so we need to revert the commit, and also update the QueryActivatedHeight logic in OPStackL2 consumer controller.
