### PR TITLE
chore: add `clean-e2e` command to kill dangling babylond or wasmd processed when e2e tests fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,11 +67,17 @@ install-wasmd:
 	cd $(TOOLS_DIR); \
 	go install -trimpath $(WASMD_PKG)
 
+.PHONY: clean-e2e
+clean-e2e:
+	ps aux | grep -E 'babylond start|wasmd start' | grep -v grep | awk '{print $$2}' | xargs kill
+
 test-e2e: install-babylond install-wasmd
+	make clean-e2e
 	go test -mod=readonly -timeout=25m -v $(PACKAGES_E2E) -count=1 --tags=e2e
 	go test -mod=readonly -timeout=25m -v $(PACKAGES_E2E) -count=1 --tags=e2e_op
 
 test-e2e-op: install-babylond
+	make clean-e2e
 	go test -mod=readonly -timeout=25m -v $(PACKAGES_E2E) -count=1 --tags=e2e_op
 
 ###############################################################################

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,12 @@ install-wasmd:
 
 .PHONY: clean-e2e
 clean-e2e:
-	ps aux | grep -E 'babylond start|wasmd start' | grep -v grep | awk '{print $$2}' | xargs kill
+# find babylond adn wasmd process ids (in one line, seperated by space)
+	@pids=$$(ps aux | grep -E 'babylond start|wasmd start' | grep -v grep | awk '{print $$2}' | tr '\n' ' '); \
+	if [ -n "$$pids" ]; then \
+		echo $$pids | xargs kill; \
+		echo "Killed process $$pids"; \
+	fi
 
 test-e2e: install-babylond install-wasmd
 	make clean-e2e

--- a/clientcontroller/opstackl2/consumer.go
+++ b/clientcontroller/opstackl2/consumer.go
@@ -344,16 +344,17 @@ func (cc *OPStackL2ConsumerController) QueryLastCommittedPublicRand(fpPk *btcec.
 		return nil, fmt.Errorf("failed to query smart contract state: %w", err)
 	}
 
-	var resp LastPubRandCommitResponse
-	err = json.Unmarshal(stateResp.Data, &resp)
-	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
-	}
-
 	respMap := make(map[uint64]*types.PubRandCommit)
-	respMap[resp.StartHeight] = &types.PubRandCommit{
-		NumPubRand: resp.NumPubRand,
-		Commitment: resp.Commitment,
+	if stateResp.Data != nil {
+		var resp LastPubRandCommitResponse
+		err = json.Unmarshal(stateResp.Data, &resp)
+		if err != nil {
+			return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+		}
+		respMap[resp.StartHeight] = &types.PubRandCommit{
+			NumPubRand: resp.NumPubRand,
+			Commitment: resp.Commitment,
+		}
 	}
 
 	return respMap, nil


### PR DESCRIPTION
context https://github.com/babylonchain/finality-provider/issues/397

note that this just a workaround, we probably should avoid this happen in the first place

but this PR is good for now