### PR TITLE
refactor: expose a few private names from e2e test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,11 +67,17 @@ install-wasmd:
 	cd $(TOOLS_DIR); \
 	go install -trimpath $(WASMD_PKG)
 
+.PHONY: clean-e2e
+clean-e2e:
+	ps aux | grep -E 'babylond start|wasmd start' | grep -v grep | awk '{print $$2}' | xargs kill
+
 test-e2e: install-babylond install-wasmd
+	make clean-e2e
 	go test -mod=readonly -timeout=25m -v $(PACKAGES_E2E) -count=1 --tags=e2e
 	go test -mod=readonly -timeout=25m -v $(PACKAGES_E2E) -count=1 --tags=e2e_op
 
 test-e2e-op: install-babylond
+	make clean-e2e
 	go test -mod=readonly -timeout=25m -v $(PACKAGES_E2E) -count=1 --tags=e2e_op
 
 ###############################################################################

--- a/clientcontroller/opstackl2/consumer.go
+++ b/clientcontroller/opstackl2/consumer.go
@@ -344,16 +344,17 @@ func (cc *OPStackL2ConsumerController) QueryLastCommittedPublicRand(fpPk *btcec.
 		return nil, fmt.Errorf("failed to query smart contract state: %w", err)
 	}
 
-	var resp LastPubRandCommitResponse
-	err = json.Unmarshal(stateResp.Data, &resp)
-	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
-	}
-
 	respMap := make(map[uint64]*types.PubRandCommit)
-	respMap[resp.StartHeight] = &types.PubRandCommit{
-		NumPubRand: resp.NumPubRand,
-		Commitment: resp.Commitment,
+	if stateResp.Data != nil {
+		var resp LastPubRandCommitResponse
+		err = json.Unmarshal(stateResp.Data, &resp)
+		if err != nil {
+			return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+		}
+		respMap[resp.StartHeight] = &types.PubRandCommit{
+			NumPubRand: resp.NumPubRand,
+			Commitment: resp.Commitment,
+		}
 	}
 
 	return respMap, nil

--- a/finality-provider/service/fp_instance.go
+++ b/finality-provider/service/fp_instance.go
@@ -363,20 +363,6 @@ func (fp *FinalityProviderInstance) tryFastSync(targetBlockHeight uint64) (*Fast
 		return nil, fmt.Errorf("the finality-provider %s is already in sync", fp.GetBtcPkHex())
 	}
 
-	// get the activated height from the consumer controller
-	activatedHeight, err := fp.consumerCon.QueryActivatedHeight()
-	if err != nil {
-		return nil, err
-	}
-	if targetBlockHeight < activatedHeight {
-		fp.logger.Debug(
-			"finality provider is not activated yet on the consumer, no need to catch up",
-			zap.Uint64("activated height", activatedHeight),
-			zap.Uint64("target height", targetBlockHeight),
-		)
-		return nil, nil
-	}
-
 	// get the last finalized height
 	lastFinalizedBlock, err := fp.latestFinalizedBlockWithRetry()
 	if err != nil {

--- a/itest/consumer_test_manager.go
+++ b/itest/consumer_test_manager.go
@@ -162,20 +162,20 @@ func StartConsumerManagerWithFps(t *testing.T, n int) (*ConsumerTestManager, []*
 	app := ctm.Fpa
 
 	for i := 0; i < n; i++ {
-		fpName := fpNamePrefix + strconv.Itoa(i)
-		moniker := monikerPrefix + strconv.Itoa(i)
+		fpName := FpNamePrefix + strconv.Itoa(i)
+		moniker := MonikerPrefix + strconv.Itoa(i)
 		commission := sdkmath.LegacyZeroDec()
-		desc := newDescription(moniker)
+		desc := NewDescription(moniker)
 		cfg := app.GetConfig()
-		_, err := service.CreateChainKey(cfg.BabylonConfig.KeyDirectory, cfg.BabylonConfig.ChainID, fpName, keyring.BackendTest, passphrase, hdPath, "")
+		_, err := service.CreateChainKey(cfg.BabylonConfig.KeyDirectory, cfg.BabylonConfig.ChainID, fpName, keyring.BackendTest, Passphrase, HdPath, "")
 		require.NoError(t, err)
-		res, err := app.CreateFinalityProvider(fpName, chainID, passphrase, hdPath, desc, &commission)
+		res, err := app.CreateFinalityProvider(fpName, ChainID, Passphrase, HdPath, desc, &commission)
 		require.NoError(t, err)
 		fpPk, err := bbntypes.NewBIP340PubKeyFromHex(res.FpInfo.BtcPkHex)
 		require.NoError(t, err)
 		_, err = app.RegisterFinalityProvider(fpPk.MarshalHex())
 		require.NoError(t, err)
-		err = app.StartHandlingFinalityProvider(fpPk, passphrase)
+		err = app.StartHandlingFinalityProvider(fpPk, Passphrase)
 		require.NoError(t, err)
 		fpIns, err := app.GetFinalityProviderInstance(fpPk)
 		require.NoError(t, err)
@@ -195,7 +195,7 @@ func StartConsumerManagerWithFps(t *testing.T, n int) (*ConsumerTestManager, []*
 			}
 
 			for _, fp := range fps {
-				if !strings.Contains(fp.Description.Moniker, monikerPrefix) {
+				if !strings.Contains(fp.Description.Moniker, MonikerPrefix) {
 					return false
 				}
 				if !fp.Commission.Equal(sdkmath.LegacyZeroDec()) {
@@ -222,13 +222,13 @@ func (ctm *ConsumerTestManager) CreateFinalityProvidersForChain(t *testing.T, ch
 	// register all finality providers
 	fpPKs := make([]*bbntypes.BIP340PubKey, 0, n)
 	for i := 0; i < n; i++ {
-		fpName := fpNamePrefix + chainID + "-" + strconv.Itoa(i)
-		moniker := monikerPrefix + chainID + "-" + strconv.Itoa(i)
+		fpName := FpNamePrefix + chainID + "-" + strconv.Itoa(i)
+		moniker := MonikerPrefix + chainID + "-" + strconv.Itoa(i)
 		commission := sdkmath.LegacyZeroDec()
-		desc := newDescription(moniker)
-		_, err := service.CreateChainKey(cfg.BabylonConfig.KeyDirectory, chainID, fpName, keyring.BackendTest, passphrase, hdPath, "")
+		desc := NewDescription(moniker)
+		_, err := service.CreateChainKey(cfg.BabylonConfig.KeyDirectory, chainID, fpName, keyring.BackendTest, Passphrase, HdPath, "")
 		require.NoError(t, err)
-		res, err := app.CreateFinalityProvider(fpName, chainID, passphrase, hdPath, desc, &commission)
+		res, err := app.CreateFinalityProvider(fpName, chainID, Passphrase, HdPath, desc, &commission)
 		require.NoError(t, err)
 		fpPk, err := bbntypes.NewBIP340PubKeyFromHex(res.FpInfo.BtcPkHex)
 		require.NoError(t, err)
@@ -239,7 +239,7 @@ func (ctm *ConsumerTestManager) CreateFinalityProvidersForChain(t *testing.T, ch
 
 	for i := 0; i < n; i++ {
 		// start
-		err := app.StartHandlingFinalityProvider(fpPKs[i], passphrase)
+		err := app.StartHandlingFinalityProvider(fpPKs[i], Passphrase)
 		require.NoError(t, err)
 		fpIns, err := app.GetFinalityProviderInstance(fpPKs[i])
 		require.NoError(t, err)
@@ -260,7 +260,7 @@ func (ctm *ConsumerTestManager) CreateFinalityProvidersForChain(t *testing.T, ch
 		}
 
 		for _, fp := range fps {
-			if !strings.Contains(fp.Description.Moniker, monikerPrefix) {
+			if !strings.Contains(fp.Description.Moniker, MonikerPrefix) {
 				return false
 			}
 			if !fp.Commission.Equal(sdkmath.LegacyZeroDec()) {

--- a/itest/test_manager.go
+++ b/itest/test_manager.go
@@ -25,7 +25,6 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
-	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
@@ -38,16 +37,8 @@ import (
 )
 
 var (
-	EventuallyWaitTimeOut = 1 * time.Minute
-	EventuallyPollTime    = 500 * time.Millisecond
-	btcNetworkParams      = &chaincfg.SimNetParams
-
-	FpNamePrefix  = "test-fp-"
-	MonikerPrefix = "moniker-"
-	ChainID       = "chain-test"
-	Passphrase    = "testpass"
-	HdPath        = ""
-	simnetParams  = &chaincfg.SimNetParams
+	btcNetworkParams = &chaincfg.SimNetParams
+	simnetParams     = &chaincfg.SimNetParams
 )
 
 type TestManager struct {
@@ -681,11 +672,6 @@ func DefaultFpConfig(keyringDir, homeDir string) *fpcfg.Config {
 	cfg.BabylonConfig.GasAdjustment = 20
 
 	return &cfg
-}
-
-func NewDescription(moniker string) *stakingtypes.Description {
-	dec := stakingtypes.NewDescription(moniker, "", "", "", "")
-	return &dec
 }
 
 // ParseRespBTCDelToBTCDel parses an BTC delegation response to BTC Delegation

--- a/itest/test_manager.go
+++ b/itest/test_manager.go
@@ -42,11 +42,11 @@ var (
 	EventuallyPollTime    = 500 * time.Millisecond
 	btcNetworkParams      = &chaincfg.SimNetParams
 
-	fpNamePrefix  = "test-fp-"
-	monikerPrefix = "moniker-"
-	chainID       = "chain-test"
-	passphrase    = "testpass"
-	hdPath        = ""
+	FpNamePrefix  = "test-fp-"
+	MonikerPrefix = "moniker-"
+	ChainID       = "chain-test"
+	Passphrase    = "testpass"
+	HdPath        = ""
 	simnetParams  = &chaincfg.SimNetParams
 )
 
@@ -157,20 +157,20 @@ func StartManagerWithFinalityProvider(t *testing.T, n int) (*TestManager, []*ser
 	app := tm.Fpa
 
 	for i := 0; i < n; i++ {
-		fpName := fpNamePrefix + strconv.Itoa(i)
-		moniker := monikerPrefix + strconv.Itoa(i)
+		fpName := FpNamePrefix + strconv.Itoa(i)
+		moniker := MonikerPrefix + strconv.Itoa(i)
 		commission := sdkmath.LegacyZeroDec()
-		desc := newDescription(moniker)
+		desc := NewDescription(moniker)
 		cfg := app.GetConfig()
-		_, err := service.CreateChainKey(cfg.BabylonConfig.KeyDirectory, cfg.BabylonConfig.ChainID, fpName, keyring.BackendTest, passphrase, hdPath, "")
+		_, err := service.CreateChainKey(cfg.BabylonConfig.KeyDirectory, cfg.BabylonConfig.ChainID, fpName, keyring.BackendTest, Passphrase, HdPath, "")
 		require.NoError(t, err)
-		res, err := app.CreateFinalityProvider(fpName, chainID, passphrase, hdPath, desc, &commission)
+		res, err := app.CreateFinalityProvider(fpName, ChainID, Passphrase, HdPath, desc, &commission)
 		require.NoError(t, err)
 		fpPk, err := bbntypes.NewBIP340PubKeyFromHex(res.FpInfo.BtcPkHex)
 		require.NoError(t, err)
 		_, err = app.RegisterFinalityProvider(fpPk.MarshalHex())
 		require.NoError(t, err)
-		err = app.StartHandlingFinalityProvider(fpPk, passphrase)
+		err = app.StartHandlingFinalityProvider(fpPk, Passphrase)
 		require.NoError(t, err)
 		fpIns, err := app.GetFinalityProviderInstance(fpPk)
 		require.NoError(t, err)
@@ -190,7 +190,7 @@ func StartManagerWithFinalityProvider(t *testing.T, n int) (*TestManager, []*ser
 			}
 
 			for _, fp := range fps {
-				if !strings.Contains(fp.Description.Moniker, monikerPrefix) {
+				if !strings.Contains(fp.Description.Moniker, MonikerPrefix) {
 					return false
 				}
 				if !fp.Commission.Equal(sdkmath.LegacyZeroDec()) {
@@ -205,7 +205,7 @@ func StartManagerWithFinalityProvider(t *testing.T, n int) (*TestManager, []*ser
 	fpInsList := app.ListFinalityProviderInstances()
 	require.Equal(t, n, len(fpInsList))
 
-	t.Logf("the test manager is running with %v finality-provider(s)", len(fpInsList))
+	t.Logf("The test manager is running with %v finality-provider(s)", len(fpInsList))
 
 	return tm, fpInsList
 }
@@ -396,7 +396,7 @@ func (tm *TestManager) StopAndRestartFpAfterNBlocks(t *testing.T, n uint, fpIns 
 }
 
 func (tm *TestManager) GetFpPrivKey(t *testing.T, fpPk []byte) *btcec.PrivateKey {
-	record, err := tm.EOTSClient.KeyRecord(fpPk, passphrase)
+	record, err := tm.EOTSClient.KeyRecord(fpPk, Passphrase)
 	require.NoError(t, err)
 	return record.PrivKey
 }
@@ -683,7 +683,7 @@ func DefaultFpConfig(keyringDir, homeDir string) *fpcfg.Config {
 	return &cfg
 }
 
-func newDescription(moniker string) *stakingtypes.Description {
+func NewDescription(moniker string) *stakingtypes.Description {
 	dec := stakingtypes.NewDescription(moniker, "", "", "", "")
 	return &dec
 }

--- a/itest/utils.go
+++ b/itest/utils.go
@@ -1,6 +1,26 @@
 package e2etest
 
-import "os"
+import (
+	"os"
+	"time"
+
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+)
+
+var (
+	EventuallyWaitTimeOut = 1 * time.Minute
+	EventuallyPollTime    = 500 * time.Millisecond
+	FpNamePrefix          = "test-fp-"
+	MonikerPrefix         = "moniker-"
+	ChainID               = "chain-test"
+	Passphrase            = "testpass"
+	HdPath                = ""
+)
+
+func NewDescription(moniker string) *stakingtypes.Description {
+	dec := stakingtypes.NewDescription(moniker, "", "", "", "")
+	return &dec
+}
 
 func BaseDir(pattern string) (string, error) {
 	tempPath := os.TempDir()


### PR DESCRIPTION
## Summary

our own e2e test will use those names

move them to utils.go

in the future, we should refactor to create independent packages for opl2, wasm, and babylon consumers but that's outside of the scope of this PR

## Test Plan

```
make test-e2e
make test
```