### PR TITLE
refactor: move some e2e methods

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,10 @@ build-docker:
 
 .PHONY: build build-docker
 
+.PHONY: lint
+lint:
+	golangci-lint run
+
 .PHONY: test
 test:
 	go test ./...

--- a/clientcontroller/babylon/babylon.go
+++ b/clientcontroller/babylon/babylon.go
@@ -146,6 +146,9 @@ func (bc *BabylonController) RegisterFinalityProvider(
 	return &types.TxResponse{TxHash: res.TxHash}, nil
 }
 
+// TODO: only used in test. this should not be put here. it causes confusion that this is a method
+// that will be used when FP runs. in that's the case, it implies it should work all all consumer
+// types. but `bbnClient.QueryClient.FinalityProviders` doesn't work for consumer chains
 func (bc *BabylonController) QueryFinalityProviderSlashed(fpPk *btcec.PublicKey) (bool, error) {
 	fpPubKey := bbntypes.NewBIP340PubKeyFromBTCPK(fpPk)
 	res, err := bc.bbnClient.QueryClient.FinalityProvider(fpPubKey.MarshalHex())
@@ -313,6 +316,7 @@ func (bc *BabylonController) QueryBtcLightClientTip() (*btclctypes.BTCHeaderInfo
 	return res.Header, nil
 }
 
+// TODO: this method only used in test. this should be refactored out to test files
 func (bc *BabylonController) QueryVotesAtHeight(height uint64) ([]bbntypes.BIP340PubKey, error) {
 	res, err := bc.bbnClient.QueryClient.VotesAtHeight(height)
 	if err != nil {

--- a/itest/opstackl2/op_e2e_test.go
+++ b/itest/opstackl2/op_e2e_test.go
@@ -4,92 +4,12 @@
 package e2etest_op
 
 import (
-	"bytes"
-	"compress/gzip"
 	"encoding/json"
-	"fmt"
-	"os"
-	"strings"
 	"testing"
 
-	wasmdtypes "github.com/CosmWasm/wasmd/x/wasm/types"
-	"github.com/babylonchain/finality-provider/clientcontroller/opstackl2"
 	sdkquerytypes "github.com/cosmos/cosmos-sdk/types/query"
 	"github.com/stretchr/testify/require"
 )
-
-const (
-	opFinalityGadgetContractPath = "../bytecode/op_finality_gadget.wasm"
-	opConsumerId                 = "op-stack-l2-12345"
-	opActivatedHeight            = 1022293
-)
-
-func storeWasmCode(opL2cc *opstackl2.OPStackL2ConsumerController, wasmFile string) error {
-	wasmCode, err := os.ReadFile(wasmFile)
-	if err != nil {
-		return err
-	}
-	if strings.HasSuffix(wasmFile, "wasm") { // compress for gas limit
-		var buf bytes.Buffer
-		gz := gzip.NewWriter(&buf)
-		_, err = gz.Write(wasmCode)
-		if err != nil {
-			return err
-		}
-		err = gz.Close()
-		if err != nil {
-			return err
-		}
-		wasmCode = buf.Bytes()
-	}
-
-	storeMsg := &wasmdtypes.MsgStoreCode{
-		Sender:       opL2cc.CwClient.MustGetAddr(),
-		WASMByteCode: wasmCode,
-	}
-	_, err = opL2cc.ReliablySendMsg(storeMsg, nil, nil)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func instantiateWasmContract(opL2cc *opstackl2.OPStackL2ConsumerController, codeID uint64, initMsg []byte) error {
-	instantiateMsg := &wasmdtypes.MsgInstantiateContract{
-		Sender: opL2cc.CwClient.MustGetAddr(),
-		Admin:  opL2cc.CwClient.MustGetAddr(),
-		CodeID: codeID,
-		Label:  "op-test",
-		Msg:    initMsg,
-		Funds:  nil,
-	}
-
-	_, err := opL2cc.ReliablySendMsg(instantiateMsg, nil, nil)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// returns the latest wasm code id.
-func getLatestCodeId(opL2cc *opstackl2.OPStackL2ConsumerController) (uint64, error) {
-	pagination := &sdkquerytypes.PageRequest{
-		Limit:   1,
-		Reverse: true,
-	}
-	resp, err := opL2cc.CwClient.ListCodes(pagination)
-	if err != nil {
-		return 0, err
-	}
-
-	if len(resp.CodeInfos) == 0 {
-		return 0, fmt.Errorf("no codes found")
-	}
-
-	return resp.CodeInfos[0].CodeID, nil
-}
 
 // tests the finality signature submission to the btc staking contract using admin
 func TestOpSubmitFinalitySignature(t *testing.T) {
@@ -97,9 +17,9 @@ func TestOpSubmitFinalitySignature(t *testing.T) {
 	defer ctm.Stop(t)
 
 	// store op-finality-gadget contract
-	err := storeWasmCode(ctm.OpL2ConsumerCtrl, opFinalityGadgetContractPath)
+	err := ctm.StoreWasmCode(opFinalityGadgetContractPath)
 	require.NoError(t, err)
-	opFinalityGadgetContractWasmId, err := getLatestCodeId(ctm.OpL2ConsumerCtrl)
+	opFinalityGadgetContractWasmId, err := ctm.GetLatestCodeId()
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), opFinalityGadgetContractWasmId, "first deployed contract code_id should be 1")
 
@@ -107,11 +27,11 @@ func TestOpSubmitFinalitySignature(t *testing.T) {
 	opFinalityGadgetInitMsg := map[string]interface{}{
 		"admin":            ctm.OpL2ConsumerCtrl.CwClient.MustGetAddr(),
 		"consumer_id":      opConsumerId,
-		"activated_height": opActivatedHeight,
+		"activated_height": 0,
 	}
 	opFinalityGadgetInitMsgBytes, err := json.Marshal(opFinalityGadgetInitMsg)
 	require.NoError(t, err)
-	err = instantiateWasmContract(ctm.OpL2ConsumerCtrl, opFinalityGadgetContractWasmId, opFinalityGadgetInitMsgBytes)
+	err = ctm.InstantiateWasmContract(opFinalityGadgetContractWasmId, opFinalityGadgetInitMsgBytes)
 	require.NoError(t, err)
 
 	// get op contract address

--- a/itest/opstackl2/op_test_manager.go
+++ b/itest/opstackl2/op_test_manager.go
@@ -23,11 +23,6 @@ import (
 	"go.uber.org/zap"
 )
 
-const (
-	opFinalityGadgetContractPath = "../bytecode/op_finality_gadget.wasm"
-	opConsumerId                 = "op-stack-l2-12345"
-)
-
 type OpL2ConsumerTestManager struct {
 	BabylonHandler   *e2etest.BabylonNodeHandler
 	FpConfig         *fpcfg.Config

--- a/itest/opstackl2/op_test_manager.go
+++ b/itest/opstackl2/op_test_manager.go
@@ -1,3 +1,6 @@
+//go:build e2e_op
+// +build e2e_op
+
 package e2etest_op
 
 import (
@@ -21,6 +24,11 @@ import (
 	sdkquery "github.com/cosmos/cosmos-sdk/types/query"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+)
+
+const (
+	opFinalityGadgetContractPath = "../bytecode/op_finality_gadget.wasm"
+	opConsumerId                 = "op-stack-l2-12345"
 )
 
 type OpL2ConsumerTestManager struct {

--- a/itest/opstackl2/op_test_manager.go
+++ b/itest/opstackl2/op_test_manager.go
@@ -1,11 +1,16 @@
 package e2etest_op
 
 import (
+	"bytes"
+	"compress/gzip"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
+	wasmdtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	bbncfg "github.com/babylonchain/babylon/client/config"
 	bbncc "github.com/babylonchain/finality-provider/clientcontroller/babylon"
 	"github.com/babylonchain/finality-provider/clientcontroller/opstackl2"
@@ -13,8 +18,14 @@ import (
 	e2etest "github.com/babylonchain/finality-provider/itest"
 	"github.com/babylonchain/finality-provider/types"
 	"github.com/btcsuite/btcd/btcec/v2"
+	sdkquery "github.com/cosmos/cosmos-sdk/types/query"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+)
+
+const (
+	opFinalityGadgetContractPath = "../bytecode/op_finality_gadget.wasm"
+	opConsumerId                 = "op-stack-l2-12345"
 )
 
 type OpL2ConsumerTestManager struct {
@@ -105,6 +116,73 @@ func (ctm *OpL2ConsumerTestManager) WaitForServicesStart(t *testing.T) {
 		return true
 	}, e2etest.EventuallyWaitTimeOut, e2etest.EventuallyPollTime)
 	t.Logf("Babylon node is started")
+}
+
+func (ctm *OpL2ConsumerTestManager) StoreWasmCode(wasmFile string) error {
+	wasmCode, err := os.ReadFile(wasmFile)
+	if err != nil {
+		return err
+	}
+	if strings.HasSuffix(wasmFile, "wasm") { // compress for gas limit
+		var buf bytes.Buffer
+		gz := gzip.NewWriter(&buf)
+		_, err = gz.Write(wasmCode)
+		if err != nil {
+			return err
+		}
+		err = gz.Close()
+		if err != nil {
+			return err
+		}
+		wasmCode = buf.Bytes()
+	}
+
+	storeMsg := &wasmdtypes.MsgStoreCode{
+		Sender:       ctm.OpL2ConsumerCtrl.CwClient.MustGetAddr(),
+		WASMByteCode: wasmCode,
+	}
+	_, err = ctm.OpL2ConsumerCtrl.ReliablySendMsg(storeMsg, nil, nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (ctm *OpL2ConsumerTestManager) InstantiateWasmContract(codeID uint64, initMsg []byte) error {
+	instantiateMsg := &wasmdtypes.MsgInstantiateContract{
+		Sender: ctm.OpL2ConsumerCtrl.CwClient.MustGetAddr(),
+		Admin:  ctm.OpL2ConsumerCtrl.CwClient.MustGetAddr(),
+		CodeID: codeID,
+		Label:  "op-test",
+		Msg:    initMsg,
+		Funds:  nil,
+	}
+
+	_, err := ctm.OpL2ConsumerCtrl.ReliablySendMsg(instantiateMsg, nil, nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// returns the latest wasm code id.
+func (ctm *OpL2ConsumerTestManager) GetLatestCodeId() (uint64, error) {
+	pagination := &sdkquery.PageRequest{
+		Limit:   1,
+		Reverse: true,
+	}
+	resp, err := ctm.OpL2ConsumerCtrl.CwClient.ListCodes(pagination)
+	if err != nil {
+		return 0, err
+	}
+
+	if len(resp.CodeInfos) == 0 {
+		return 0, fmt.Errorf("no codes found")
+	}
+
+	return resp.CodeInfos[0].CodeID, nil
 }
 
 func (ctm *OpL2ConsumerTestManager) Stop(t *testing.T) {


### PR DESCRIPTION
## Summary

move a few helper methods from itest/opstackl2/op_e2e_test.go to itest/opstackl2/op_test_manager.go

also added `make lint` command to be consistent with CI. so next step we don't need to wait for CI to detect any lint issues

## Test Plan

```
make lint
make test-e2e
make test
```

wait for CI tests