### PR TITLE
test: refactor the e2e test for opstack l2

### DIFF
--- a/itest/e2e_test.go
+++ b/itest/e2e_test.go
@@ -16,11 +16,6 @@ import (
 	"github.com/babylonchain/finality-provider/types"
 )
 
-var (
-	stakingTime   = uint16(100)
-	stakingAmount = int64(20000)
-)
-
 // TestFinalityProviderLifeCycle tests the whole life cycle of a finality-provider
 // creation -> registration -> randomness commitment ->
 // activation with BTC delegation and Covenant sig ->
@@ -35,7 +30,7 @@ func TestFinalityProviderLifeCycle(t *testing.T) {
 	tm.WaitForFpPubRandCommitted(t, fpIns)
 
 	// send a BTC delegation
-	_ = tm.InsertBTCDelegation(t, []*btcec.PublicKey{fpIns.GetBtcPk()}, stakingTime, stakingAmount)
+	_ = tm.InsertBTCDelegation(t, []*btcec.PublicKey{fpIns.GetBtcPk()}, StakingTime, StakingAmount)
 
 	// check the BTC delegation is pending
 	delsResp := tm.WaitForNPendingDels(t, 1)
@@ -67,7 +62,7 @@ func TestDoubleSigning(t *testing.T) {
 	tm.WaitForFpPubRandCommitted(t, fpIns)
 
 	// send a BTC delegation
-	_ = tm.InsertBTCDelegation(t, []*btcec.PublicKey{fpIns.GetBtcPk()}, stakingTime, stakingAmount)
+	_ = tm.InsertBTCDelegation(t, []*btcec.PublicKey{fpIns.GetBtcPk()}, StakingTime, StakingAmount)
 
 	// check the BTC delegation is pending
 	delsResp := tm.WaitForNPendingDels(t, 1)
@@ -125,7 +120,7 @@ func TestMultipleFinalityProviders(t *testing.T) {
 		// check the public randomness is committed
 		tm.WaitForFpPubRandCommitted(t, fpi)
 		// send a BTC delegation
-		_ = tm.InsertBTCDelegation(t, []*btcec.PublicKey{fpi.GetBtcPk()}, stakingTime, stakingAmount)
+		_ = tm.InsertBTCDelegation(t, []*btcec.PublicKey{fpi.GetBtcPk()}, StakingTime, StakingAmount)
 	}
 
 	// check the BTC delegations are pending
@@ -158,7 +153,7 @@ func TestFastSync(t *testing.T) {
 	tm.WaitForFpPubRandCommitted(t, fpIns)
 
 	// send a BTC delegation
-	_ = tm.InsertBTCDelegation(t, []*btcec.PublicKey{fpIns.GetBtcPk()}, stakingTime, stakingAmount)
+	_ = tm.InsertBTCDelegation(t, []*btcec.PublicKey{fpIns.GetBtcPk()}, StakingTime, StakingAmount)
 
 	// check the BTC delegation is pending
 	delsResp := tm.WaitForNPendingDels(t, 1)

--- a/itest/opstackl2/op_e2e_test.go
+++ b/itest/opstackl2/op_e2e_test.go
@@ -4,14 +4,12 @@
 package e2etest_op
 
 import (
-	"encoding/json"
 	"testing"
 
 	"math/rand"
 
 	"github.com/babylonchain/babylon/testutil/datagen"
 	"github.com/babylonchain/finality-provider/types"
-	sdkquerytypes "github.com/cosmos/cosmos-sdk/types/query"
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"github.com/stretchr/testify/require"
 )
@@ -20,33 +18,6 @@ import (
 func TestOpSubmitFinalitySignature(t *testing.T) {
 	ctm := StartOpL2ConsumerManager(t)
 	defer ctm.Stop(t)
-
-	// store op-finality-gadget contract
-	err := ctm.StoreWasmCode(opFinalityGadgetContractPath)
-	require.NoError(t, err)
-	opFinalityGadgetContractWasmId, err := ctm.GetLatestCodeId()
-	require.NoError(t, err)
-	require.Equal(t, uint64(1), opFinalityGadgetContractWasmId, "first deployed contract code_id should be 1")
-
-	// instantiate op contract
-	opFinalityGadgetInitMsg := map[string]interface{}{
-		"admin":            ctm.OpL2ConsumerCtrl.CwClient.MustGetAddr(),
-		"consumer_id":      opConsumerId,
-		"activated_height": 0,
-	}
-	opFinalityGadgetInitMsgBytes, err := json.Marshal(opFinalityGadgetInitMsg)
-	require.NoError(t, err)
-	err = ctm.InstantiateWasmContract(opFinalityGadgetContractWasmId, opFinalityGadgetInitMsgBytes)
-	require.NoError(t, err)
-
-	// get op contract address
-	resp, err := ctm.OpL2ConsumerCtrl.CwClient.ListContractsByCode(opFinalityGadgetContractWasmId, &sdkquerytypes.PageRequest{})
-	require.NoError(t, err)
-	require.Len(t, resp.Contracts, 1)
-	// update the contract address in config because during setup we had used a
-	// mocked address which is diff than the deployed one on the fly
-	ctm.OpL2ConsumerCtrl.Cfg.OPFinalityGadgetAddress = resp.Contracts[0]
-	t.Logf("Deployed op finality contract address: %s", resp.Contracts[0])
 
 	// register FP in Babylon Chain
 	fpList := ctm.StartFinalityProvider(t, 1)

--- a/itest/opstackl2/op_e2e_test.go
+++ b/itest/opstackl2/op_e2e_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// tests the finality signature submission to the btc staking contract using admin
+// tests the finality signature submission to the op-finality-gadget contract
 func TestOpSubmitFinalitySignature(t *testing.T) {
 	ctm := StartOpL2ConsumerManager(t)
 	defer ctm.Stop(t)

--- a/itest/opstackl2/op_e2e_test.go
+++ b/itest/opstackl2/op_e2e_test.go
@@ -22,30 +22,9 @@ func TestOpSubmitFinalitySignature(t *testing.T) {
 	// register FP in Babylon Chain
 	fpList := ctm.StartFinalityProvider(t, 1)
 
-	// generate randomness data
-	pubRandListInfo, msgPub, err := ctm.GenerateCommitPubRandListMsg(fpList[0].GetBtcPkBIP340(), 1, 100)
-	require.NoError(t, err)
-
 	// commit pub rand to smart contract
-	commitRes, err := ctm.OpL2ConsumerCtrl.CommitPubRandList(
-		msgPub.FpBtcPk.MustToBTCPK(),
-		msgPub.StartHeight,
-		msgPub.NumPubRand,
-		msgPub.Commitment,
-		msgPub.Sig.MustToBTCSig(),
-	)
-	require.NoError(t, err)
-	t.Logf("Commit PubRandList to op finality contract %s", commitRes.TxHash)
-
-	// query pub rand
-	committedPubRandMap, err := ctm.OpL2ConsumerCtrl.QueryLastCommittedPublicRand(msgPub.FpBtcPk.MustToBTCPK(), 1)
-	require.NoError(t, err)
-	for k, v := range committedPubRandMap {
-		require.Equal(t, uint64(1), k)
-		require.Equal(t, uint64(100), v.NumPubRand)
-		require.Equal(t, msgPub.Commitment, v.Commitment)
-		break
-	}
+	pubRandListInfo, msgPub := ctm.CommitPubRandList(t, fpList[0].GetBtcPkBIP340())
+	ctm.WaitForFpPubRandCommitted(t, msgPub)
 
 	// mock block
 	r := rand.New(rand.NewSource(1))

--- a/itest/opstackl2/op_e2e_test.go
+++ b/itest/opstackl2/op_e2e_test.go
@@ -24,7 +24,7 @@ func TestOpSubmitFinalitySignature(t *testing.T) {
 
 	// commit pub rand to smart contract
 	pubRandListInfo, msgPub := ctm.CommitPubRandList(t, fpList[0].GetBtcPkBIP340())
-	ctm.WaitForFpPubRandCommitted(t, msgPub)
+	ctm.WaitForFpPubRandCommitted(t, fpList[0].GetBtcPkBIP340())
 
 	// mock block
 	r := rand.New(rand.NewSource(1))

--- a/itest/opstackl2/op_test_manager.go
+++ b/itest/opstackl2/op_test_manager.go
@@ -317,17 +317,16 @@ func (ctm *OpL2ConsumerTestManager) CommitPubRandList(t *testing.T, fpPk *bbntyp
 	return pubRandListInfo, msgPub
 }
 
-func (ctm *OpL2ConsumerTestManager) WaitForFpPubRandCommitted(t *testing.T, msgPub *ftypes.MsgCommitPubRandList) {
+func (ctm *OpL2ConsumerTestManager) WaitForFpPubRandCommitted(t *testing.T, fpPk *bbntypes.BIP340PubKey) {
 	require.Eventually(t, func() bool {
 		// query pub rand
-		committedPubRandMap, err := ctm.OpL2ConsumerCtrl.QueryLastCommittedPublicRand(msgPub.FpBtcPk.MustToBTCPK(), 1)
+		committedPubRandMap, err := ctm.OpL2ConsumerCtrl.QueryLastCommittedPublicRand(fpPk.MustToBTCPK(), 1)
 		if err != nil {
 			return false
 		}
 		for k, v := range committedPubRandMap {
 			require.Equal(t, uint64(1), k)
 			require.Equal(t, uint64(100), v.NumPubRand)
-			require.Equal(t, msgPub.Commitment, v.Commitment)
 			break
 		}
 		return true

--- a/itest/opstackl2/op_test_manager.go
+++ b/itest/opstackl2/op_test_manager.go
@@ -52,10 +52,9 @@ type OpL2ConsumerTestManager struct {
 	FpApp             *service.FinalityProviderApp
 	FpConfig          *fpcfg.Config
 	OpL2ConsumerCtrl  *opstackl2.OPStackL2ConsumerController
-	// TODO: not sure if needed, if not can remove
-	StakingParams    *types.StakingParams
-	CovenantPrivKeys []*btcec.PrivateKey
-	baseDir          string
+	StakingParams     *types.StakingParams
+	CovenantPrivKeys  []*btcec.PrivateKey
+	baseDir           string
 }
 
 func StartOpL2ConsumerManager(t *testing.T) *OpL2ConsumerTestManager {

--- a/itest/opstackl2/op_test_manager.go
+++ b/itest/opstackl2/op_test_manager.go
@@ -54,7 +54,7 @@ type OpL2ConsumerTestManager struct {
 	OpL2ConsumerCtrl  *opstackl2.OPStackL2ConsumerController
 	StakingParams     *types.StakingParams
 	CovenantPrivKeys  []*btcec.PrivateKey
-	baseDir           string
+	BaseDir           string
 }
 
 func StartOpL2ConsumerManager(t *testing.T) *OpL2ConsumerTestManager {
@@ -113,7 +113,7 @@ func StartOpL2ConsumerManager(t *testing.T) *OpL2ConsumerTestManager {
 		FpConfig:          cfg,
 		OpL2ConsumerCtrl:  opcc,
 		CovenantPrivKeys:  covenantPrivKeys,
-		baseDir:           testDir,
+		BaseDir:           testDir,
 	}
 
 	ctm.WaitForServicesStart(t)
@@ -377,6 +377,6 @@ func (ctm *OpL2ConsumerTestManager) Stop(t *testing.T) {
 	err = ctm.BabylonHandler.Stop()
 	require.NoError(t, err)
 	ctm.EOTSServerHandler.Stop()
-	err = os.RemoveAll(ctm.baseDir)
+	err = os.RemoveAll(ctm.BaseDir)
 	require.NoError(t, err)
 }

--- a/itest/opstackl2/op_test_manager.go
+++ b/itest/opstackl2/op_test_manager.go
@@ -89,7 +89,7 @@ func StartOpL2ConsumerManager(t *testing.T) *OpL2ConsumerTestManager {
 	opcc, err := opstackl2.NewOPStackL2ConsumerController(mockOpL2ConsumerCtrlConfig(bh.GetNodeDataDir()), logger)
 	require.NoError(t, err)
 
-	// store op-finality-gadget contract
+	// 5. store op-finality-gadget contract
 	err = storeWasmCode(opcc, opFinalityGadgetContractPath)
 	require.NoError(t, err)
 
@@ -97,7 +97,7 @@ func StartOpL2ConsumerManager(t *testing.T) *OpL2ConsumerTestManager {
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), opFinalityGadgetContractWasmId, "first deployed contract code_id should be 1")
 
-	// instantiate op contract
+	// 6. instantiate op contract
 	opFinalityGadgetInitMsg := map[string]interface{}{
 		"admin":            opcc.CwClient.MustGetAddr(),
 		"consumer_id":      opConsumerId,
@@ -113,12 +113,12 @@ func StartOpL2ConsumerManager(t *testing.T) *OpL2ConsumerTestManager {
 	require.NoError(t, err)
 	require.Len(t, resp.Contracts, 1)
 
-	// update the contract address in config because during setup we had used a
-	// mocked address which is diff than the deployed one on the fly
+	// update the contract address in config to replace a placeholder address
+	// previously used to bypass the validation
 	opcc.Cfg.OPFinalityGadgetAddress = resp.Contracts[0]
 	t.Logf("Deployed op finality contract address: %s", resp.Contracts[0])
 
-	// 5. prepare EOTS manager
+	// 7. prepare EOTS manager
 	eotsHomeDir := filepath.Join(testDir, "eots-home")
 	eotsCfg := eotsconfig.DefaultConfigWithHomePath(eotsHomeDir)
 	eh := e2etest.NewEOTSServerHandler(t, eotsCfg, eotsHomeDir)
@@ -126,7 +126,7 @@ func StartOpL2ConsumerManager(t *testing.T) *OpL2ConsumerTestManager {
 	eotsCli, err := client.NewEOTSManagerGRpcClient(cfg.EOTSManagerAddress)
 	require.NoError(t, err)
 
-	// 6. prepare finality-provider
+	// 8. prepare finality-provider
 	fpdb, err := cfg.DatabaseConfig.GetDbBackend()
 	require.NoError(t, err)
 	fpApp, err := service.NewFinalityProviderApp(cfg, bc, opcc, eotsCli, fpdb, logger)

--- a/itest/test_manager.go
+++ b/itest/test_manager.go
@@ -36,10 +36,6 @@ import (
 	"github.com/babylonchain/finality-provider/types"
 )
 
-var (
-	btcNetworkParams = &chaincfg.SimNetParams
-)
-
 type TestManager struct {
 	Wg                sync.WaitGroup
 	BabylonHandler    *BabylonNodeHandler
@@ -407,7 +403,7 @@ func (tm *TestManager) InsertCovenantSigForDelegation(t *testing.T, btcDel *bsty
 		params.CovenantQuorum,
 		btcDel.GetStakingTime(),
 		btcutil.Amount(btcDel.TotalSat),
-		btcNetworkParams,
+		BtcNetworkParams,
 	)
 	require.NoError(t, err)
 	stakingTxUnbondingPathInfo, err := stakingInfo.UnbondingPathSpendInfo()
@@ -432,7 +428,7 @@ func (tm *TestManager) InsertCovenantSigForDelegation(t *testing.T, btcDel *bsty
 		params.CovenantQuorum,
 		uint16(btcDel.UnbondingTime),
 		btcutil.Amount(unbondingMsgTx.TxOut[0].Value),
-		btcNetworkParams,
+		BtcNetworkParams,
 	)
 	require.NoError(t, err)
 
@@ -524,7 +520,7 @@ func (tm *TestManager) InsertBTCDelegation(t *testing.T, fpPks []*btcec.PublicKe
 	testStakingInfo := datagen.GenBTCStakingSlashingInfo(
 		r,
 		t,
-		btcNetworkParams,
+		BtcNetworkParams,
 		delBtcPrivKey,
 		fpPks,
 		params.CovenantPks,
@@ -590,7 +586,7 @@ func (tm *TestManager) InsertBTCDelegation(t *testing.T, fpPks []*btcec.PublicKe
 	testUnbondingInfo := datagen.GenBTCUnbondingSlashingInfo(
 		r,
 		t,
-		btcNetworkParams,
+		BtcNetworkParams,
 		delBtcPrivKey,
 		fpPks,
 		params.CovenantPks,

--- a/itest/utils.go
+++ b/itest/utils.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/btcsuite/btcd/chaincfg"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 )
 
@@ -15,6 +16,7 @@ var (
 	ChainID               = "chain-test"
 	Passphrase            = "testpass"
 	HdPath                = ""
+	BtcNetworkParams      = &chaincfg.SimNetParams
 )
 
 func NewDescription(moniker string) *stakingtypes.Description {

--- a/itest/utils.go
+++ b/itest/utils.go
@@ -17,6 +17,8 @@ var (
 	Passphrase            = "testpass"
 	HdPath                = ""
 	BtcNetworkParams      = &chaincfg.SimNetParams
+	StakingTime           = uint16(100)
+	StakingAmount         = int64(20000)
 )
 
 func NewDescription(moniker string) *stakingtypes.Description {


### PR DESCRIPTION
This PR refactors the e2e test for opstack l2 so that some common functions can be reused in other repos.

## Test Plan

```
make test-e2e
```