### PR TITLE
fix: remove unused Babylon FP in e2e test

### DIFF
--- a/itest/opstackl2/op_e2e_test.go
+++ b/itest/opstackl2/op_e2e_test.go
@@ -18,11 +18,6 @@ func TestOpSubmitFinalitySignature(t *testing.T) {
 	ctm := StartOpL2ConsumerManager(t)
 	defer ctm.Stop(t)
 
-	// A BTC delegation has to stake to at least one Babylon finality provider
-	// https://github.com/babylonchain/babylon-private/blob/base/consumer-chain-support/x/btcstaking/keeper/msg_server.go#L169-L213
-	// So we have to start Babylon chain FP
-	ctm.StartFinalityProvider(t, true, 1)
-
 	// start consumer chain FP
 	fpList := ctm.StartFinalityProvider(t, false, 1)
 	fpInstance := fpList[0]
@@ -43,6 +38,7 @@ func TestOpSubmitFinalitySignature(t *testing.T) {
 	// generate commitment and proof for each public randomness
 	_, proofList := types.GetPubRandCommitAndProofs(pubRandList)
 
+	// create a mock block
 	r := rand.New(rand.NewSource(1))
 	block := &types.BlockInfo{
 		Height: lastCommittedStartHeight,
@@ -59,7 +55,7 @@ func TestOpSubmitFinalitySignature(t *testing.T) {
 	require.NoError(t, err)
 
 	// submit finality signature to smart contract
-	submitRes, err := ctm.OpL2ConsumerCtrl.SubmitFinalitySig(
+	_, err = ctm.OpL2ConsumerCtrl.SubmitFinalitySig(
 		fpInstance.GetBtcPk(),
 		block,
 		pubRandList[0],
@@ -67,7 +63,7 @@ func TestOpSubmitFinalitySignature(t *testing.T) {
 		fpSig.ToModNScalar(),
 	)
 	require.NoError(t, err)
-	t.Logf("Submit finality signature to op finality contract %s", submitRes.TxHash)
+	t.Logf("Submit finality signature to op finality contract")
 
 	// mock more blocks
 	blocks := []*types.BlockInfo{}
@@ -93,7 +89,7 @@ func TestOpSubmitFinalitySignature(t *testing.T) {
 	}
 
 	// submit batch finality signatures to smart contract
-	batchSubmitRes, err := ctm.OpL2ConsumerCtrl.SubmitBatchFinalitySigs(
+	_, err = ctm.OpL2ConsumerCtrl.SubmitBatchFinalitySigs(
 		fpInstance.GetBtcPk(),
 		blocks,
 		pubRandList[1:4],
@@ -101,5 +97,5 @@ func TestOpSubmitFinalitySignature(t *testing.T) {
 		fpSigs,
 	)
 	require.NoError(t, err)
-	t.Logf("Submit batch finality signatures to op finality contract %s", batchSubmitRes.TxHash)
+	t.Logf("Submit batch finality signatures to op finality contract")
 }

--- a/itest/opstackl2/op_test_manager.go
+++ b/itest/opstackl2/op_test_manager.go
@@ -80,9 +80,9 @@ func StartOpL2ConsumerManager(t *testing.T) *OpL2ConsumerTestManager {
 	require.NoError(t, err)
 
 	// 3. register consumer to Babylon
-	txRes, err := bc.RegisterConsumerChain(opConsumerId, opConsumerId, opConsumerId)
+	_, err = bc.RegisterConsumerChain(opConsumerId, opConsumerId, opConsumerId)
 	require.NoError(t, err)
-	t.Logf("Register consumer %s to Babylon %s", opConsumerId, txRes.TxHash)
+	t.Logf("Register consumer %s to Babylon", opConsumerId)
 
 	// 4. new op consumer controller
 	opcc, err := opstackl2.NewOPStackL2ConsumerController(mockOpL2ConsumerCtrlConfig(bh.GetNodeDataDir()), logger)
@@ -211,8 +211,8 @@ func (ctm *OpL2ConsumerTestManager) StartFinalityProvider(t *testing.T, isBabylo
 		require.NoError(t, err)
 		fpPk, err := bbntypes.NewBIP340PubKeyFromHex(res.FpInfo.BtcPkHex)
 		require.NoError(t, err)
-		regRes, err := app.RegisterFinalityProvider(fpPk.MarshalHex())
-		t.Logf("Registered Finality Provider %s", regRes.TxHash)
+		_, err = app.RegisterFinalityProvider(fpPk.MarshalHex())
+		t.Logf("Registered Finality Provider %s", fpPk.MarshalHex())
 		require.NoError(t, err)
 		err = app.StartHandlingFinalityProvider(fpPk, e2eutils.Passphrase)
 		require.NoError(t, err)
@@ -278,7 +278,7 @@ func (ctm *OpL2ConsumerTestManager) WaitForFpPubRandCommitted(t *testing.T, fpIn
 		return lastCommittedHeight > 0
 	}, e2eutils.EventuallyWaitTimeOut, e2eutils.EventuallyPollTime)
 
-	t.Logf("public randomness is successfully committed")
+	t.Logf("Public randomness is successfully committed")
 }
 
 func storeWasmCode(opcc *opstackl2.OPStackL2ConsumerController, wasmFile string) error {


### PR DESCRIPTION
## Summary
since we are not doing BTC delegation, we won't encounter the `ErrNoBabylonFPRestaked` error here: https://github.com/babylonchain/babylon-private/blob/base/consumer-chain-support/x/btcstaking/keeper/btc_delegations.go#L212

I also removed some unnecessary logs

## Test Plan
```
make lint
make test-e2e-op
```