### PR TITLE
refactor: move `WaitForFpPubRandCommitted` to utils to dedup

### DIFF
--- a/itest/babylon/babylon_e2e_test.go
+++ b/itest/babylon/babylon_e2e_test.go
@@ -28,7 +28,7 @@ func TestFinalityProviderLifeCycle(t *testing.T) {
 	fpIns := fpInsList[0]
 
 	// check the public randomness is committed
-	tm.WaitForFpPubRandCommitted(t, fpIns)
+	e2eutils.WaitForFpPubRandCommitted(t, fpIns)
 
 	// send a BTC delegation
 	_ = tm.InsertBTCDelegation(t, []*btcec.PublicKey{fpIns.GetBtcPk()}, e2eutils.StakingTime, e2eutils.StakingAmount)
@@ -60,7 +60,7 @@ func TestDoubleSigning(t *testing.T) {
 	fpIns := fpInsList[0]
 
 	// check the public randomness is committed
-	tm.WaitForFpPubRandCommitted(t, fpIns)
+	e2eutils.WaitForFpPubRandCommitted(t, fpIns)
 
 	// send a BTC delegation
 	_ = tm.InsertBTCDelegation(t, []*btcec.PublicKey{fpIns.GetBtcPk()}, e2eutils.StakingTime, e2eutils.StakingAmount)
@@ -119,7 +119,7 @@ func TestMultipleFinalityProviders(t *testing.T) {
 	// submit BTC delegations for each finality-provider
 	for _, fpi := range fpInstances {
 		// check the public randomness is committed
-		tm.WaitForFpPubRandCommitted(t, fpi)
+		e2eutils.WaitForFpPubRandCommitted(t, fpi)
 		// send a BTC delegation
 		_ = tm.InsertBTCDelegation(t, []*btcec.PublicKey{fpi.GetBtcPk()}, e2eutils.StakingTime, e2eutils.StakingAmount)
 	}
@@ -151,7 +151,7 @@ func TestFastSync(t *testing.T) {
 	fpIns := fpInsList[0]
 
 	// check the public randomness is committed
-	tm.WaitForFpPubRandCommitted(t, fpIns)
+	e2eutils.WaitForFpPubRandCommitted(t, fpIns)
 
 	// send a BTC delegation
 	_ = tm.InsertBTCDelegation(t, []*btcec.PublicKey{fpIns.GetBtcPk()}, e2eutils.StakingTime, e2eutils.StakingAmount)

--- a/itest/babylon/babylon_test_manager.go
+++ b/itest/babylon/babylon_test_manager.go
@@ -218,18 +218,6 @@ func (tm *TestManager) WaitForFpRegistered(t *testing.T, bbnPk *secp256k1.PubKey
 	t.Logf("the finality-provider is successfully registered")
 }
 
-func (tm *TestManager) WaitForFpPubRandCommitted(t *testing.T, fpIns *service.FinalityProviderInstance) {
-	require.Eventually(t, func() bool {
-		lastCommittedHeight, err := fpIns.GetLastCommittedHeight()
-		if err != nil {
-			return false
-		}
-		return lastCommittedHeight > 0
-	}, e2eutils.EventuallyWaitTimeOut, e2eutils.EventuallyPollTime)
-
-	t.Logf("public randomness is successfully committed")
-}
-
 func (tm *TestManager) WaitForNPendingDels(t *testing.T, n int) []*bstypes.BTCDelegationResponse {
 	var (
 		dels []*bstypes.BTCDelegationResponse

--- a/itest/babylon/babylon_test_manager.go
+++ b/itest/babylon/babylon_test_manager.go
@@ -370,13 +370,13 @@ func (tm *TestManager) GetFpPrivKey(t *testing.T, fpPk []byte) *btcec.PrivateKey
 	return record.PrivKey
 }
 
-func (stm *TestManager) InsertCovenantSigForDelegation(t *testing.T, btcDel *bstypes.BTCDelegation) {
+func (tm *TestManager) InsertCovenantSigForDelegation(t *testing.T, btcDel *bstypes.BTCDelegation) {
 	slashingTx := btcDel.SlashingTx
 	stakingTx := btcDel.StakingTx
 	stakingMsgTx, err := bbntypes.NewBTCTxFromBytes(stakingTx)
 	require.NoError(t, err)
 
-	params := stm.StakingParams
+	params := tm.StakingParams
 
 	var fpKeys []*btcec.PublicKey
 	for _, v := range btcDel.FpBtcPkList {
@@ -431,7 +431,7 @@ func (stm *TestManager) InsertCovenantSigForDelegation(t *testing.T, btcDel *bst
 			stakingMsgTx,
 			idx,
 			slashingPathInfo.RevealedLeaf.Script,
-			stm.CovenantPrivKeys[0],
+			tm.CovenantPrivKeys[0],
 			v,
 		)
 		require.NoError(t, err)
@@ -441,7 +441,7 @@ func (stm *TestManager) InsertCovenantSigForDelegation(t *testing.T, btcDel *bst
 	covenantUnbondingSig1, err := btcstaking.SignTxWithOneScriptSpendInputFromTapLeaf(
 		unbondingMsgTx,
 		stakingInfo.StakingOutput,
-		stm.CovenantPrivKeys[0],
+		tm.CovenantPrivKeys[0],
 		stakingTxUnbondingPathInfo.RevealedLeaf,
 	)
 	require.NoError(t, err)
@@ -455,15 +455,15 @@ func (stm *TestManager) InsertCovenantSigForDelegation(t *testing.T, btcDel *bst
 			unbondingMsgTx,
 			0,
 			unbondingTxSlashingPathInfo.RevealedLeaf.Script,
-			stm.CovenantPrivKeys[0],
+			tm.CovenantPrivKeys[0],
 			v,
 		)
 		require.NoError(t, err)
 		covenantAdaptorUnbondingSlashing1List = append(covenantAdaptorUnbondingSlashing1List, covenantAdaptorUnbondingSlashing1.MustMarshal())
 	}
 
-	_, err = stm.BBNClient.SubmitCovenantSigs(
-		stm.CovenantPrivKeys[0].PubKey(),
+	_, err = tm.BBNClient.SubmitCovenantSigs(
+		tm.CovenantPrivKeys[0].PubKey(),
 		stakingMsgTx.TxHash().String(),
 		covenantAdaptorStakingSlashing1List,
 		covenantUnbondingSig1,
@@ -478,7 +478,7 @@ func (stm *TestManager) InsertCovenantSigForDelegation(t *testing.T, btcDel *bst
 			stakingMsgTx,
 			idx,
 			slashingPathInfo.RevealedLeaf.Script,
-			stm.CovenantPrivKeys[1],
+			tm.CovenantPrivKeys[1],
 			v,
 		)
 		require.NoError(t, err)
@@ -488,7 +488,7 @@ func (stm *TestManager) InsertCovenantSigForDelegation(t *testing.T, btcDel *bst
 	covenantUnbondingSig2, err := btcstaking.SignTxWithOneScriptSpendInputFromTapLeaf(
 		unbondingMsgTx,
 		stakingInfo.StakingOutput,
-		stm.CovenantPrivKeys[1],
+		tm.CovenantPrivKeys[1],
 		stakingTxUnbondingPathInfo.RevealedLeaf,
 	)
 	require.NoError(t, err)
@@ -502,15 +502,15 @@ func (stm *TestManager) InsertCovenantSigForDelegation(t *testing.T, btcDel *bst
 			unbondingMsgTx,
 			0,
 			unbondingTxSlashingPathInfo.RevealedLeaf.Script,
-			stm.CovenantPrivKeys[1],
+			tm.CovenantPrivKeys[1],
 			v,
 		)
 		require.NoError(t, err)
 		covenantAdaptorUnbondingSlashing2List = append(covenantAdaptorUnbondingSlashing2List, covenantAdaptorUnbondingSlashing2.MustMarshal())
 	}
 
-	_, err = stm.BBNClient.SubmitCovenantSigs(
-		stm.CovenantPrivKeys[1].PubKey(),
+	_, err = tm.BBNClient.SubmitCovenantSigs(
+		tm.CovenantPrivKeys[1].PubKey(),
 		stakingMsgTx.TxHash().String(),
 		covenantAdaptorStakingSlashing2List,
 		covenantUnbondingSig2,

--- a/itest/babylon/babylon_test_manager.go
+++ b/itest/babylon/babylon_test_manager.go
@@ -370,18 +370,22 @@ func (tm *TestManager) GetFpPrivKey(t *testing.T, fpPk []byte) *btcec.PrivateKey
 	return record.PrivKey
 }
 
-func (tm *TestManager) InsertCovenantSigForDelegation(t *testing.T, btcDel *bstypes.BTCDelegation) {
+func (stm *TestManager) InsertCovenantSigForDelegation(t *testing.T, btcDel *bstypes.BTCDelegation) {
 	slashingTx := btcDel.SlashingTx
 	stakingTx := btcDel.StakingTx
 	stakingMsgTx, err := bbntypes.NewBTCTxFromBytes(stakingTx)
 	require.NoError(t, err)
 
-	params := tm.StakingParams
+	params := stm.StakingParams
+
+	var fpKeys []*btcec.PublicKey
+	for _, v := range btcDel.FpBtcPkList {
+		fpKeys = append(fpKeys, v.MustToBTCPK())
+	}
 
 	stakingInfo, err := btcstaking.BuildStakingInfo(
 		btcDel.BtcPk.MustToBTCPK(),
-		// TODO: Handle multiple providers
-		[]*btcec.PublicKey{btcDel.FpBtcPkList[0].MustToBTCPK()},
+		fpKeys,
 		params.CovenantPks,
 		params.CovenantQuorum,
 		btcDel.GetStakingTime(),
@@ -398,15 +402,20 @@ func (tm *TestManager) InsertCovenantSigForDelegation(t *testing.T, btcDel *bsty
 	require.NoError(t, err)
 	slashingPathInfo, err := stakingInfo.SlashingPathSpendInfo()
 	require.NoError(t, err)
-	// get covenant private key from the keyring
-	valEncKey, err := asig.NewEncryptionKeyFromBTCPK(btcDel.FpBtcPkList[0].MustToBTCPK())
-	require.NoError(t, err)
+
+	var valEncKeys []*asig.EncryptionKey
+	for _, v := range btcDel.FpBtcPkList {
+		// get covenant private key from the keyring
+		valEncKey, err := asig.NewEncryptionKeyFromBTCPK(v.MustToBTCPK())
+		require.NoError(t, err)
+		valEncKeys = append(valEncKeys, valEncKey)
+	}
 
 	unbondingMsgTx, err := bbntypes.NewBTCTxFromBytes(btcDel.BtcUndelegation.UnbondingTx)
 	require.NoError(t, err)
 	unbondingInfo, err := btcstaking.BuildUnbondingInfo(
 		btcDel.BtcPk.MustToBTCPK(),
-		[]*btcec.PublicKey{btcDel.FpBtcPkList[0].MustToBTCPK()},
+		fpKeys,
 		params.CovenantPks,
 		params.CovenantQuorum,
 		uint16(btcDel.UnbondingTime),
@@ -415,78 +424,97 @@ func (tm *TestManager) InsertCovenantSigForDelegation(t *testing.T, btcDel *bsty
 	)
 	require.NoError(t, err)
 
-	// Covenant 0 signatures
-	covenantAdaptorStakingSlashing1, err := slashingTx.EncSign(
-		stakingMsgTx,
-		idx,
-		slashingPathInfo.RevealedLeaf.Script,
-		tm.CovenantPrivKeys[0],
-		valEncKey,
-	)
-	require.NoError(t, err)
+	var covenantAdaptorStakingSlashing1List [][]byte
+	for _, v := range valEncKeys {
+		// Covenant 0 signatures
+		covenantAdaptorStakingSlashing1, err := slashingTx.EncSign(
+			stakingMsgTx,
+			idx,
+			slashingPathInfo.RevealedLeaf.Script,
+			stm.CovenantPrivKeys[0],
+			v,
+		)
+		require.NoError(t, err)
+		covenantAdaptorStakingSlashing1List = append(covenantAdaptorStakingSlashing1List, covenantAdaptorStakingSlashing1.MustMarshal())
+	}
+
 	covenantUnbondingSig1, err := btcstaking.SignTxWithOneScriptSpendInputFromTapLeaf(
 		unbondingMsgTx,
 		stakingInfo.StakingOutput,
-		tm.CovenantPrivKeys[0],
+		stm.CovenantPrivKeys[0],
 		stakingTxUnbondingPathInfo.RevealedLeaf,
 	)
 	require.NoError(t, err)
 
-	// slashing unbonding tx sig
-	unbondingTxSlashingPathInfo, err := unbondingInfo.SlashingPathSpendInfo()
-	require.NoError(t, err)
-	covenantAdaptorUnbondingSlashing1, err := btcDel.BtcUndelegation.SlashingTx.EncSign(
-		unbondingMsgTx,
-		0,
-		unbondingTxSlashingPathInfo.RevealedLeaf.Script,
-		tm.CovenantPrivKeys[0],
-		valEncKey,
-	)
-	require.NoError(t, err)
+	var covenantAdaptorUnbondingSlashing1List [][]byte
+	for _, v := range valEncKeys {
+		// slashing unbonding tx sig
+		unbondingTxSlashingPathInfo, err := unbondingInfo.SlashingPathSpendInfo()
+		require.NoError(t, err)
+		covenantAdaptorUnbondingSlashing1, err := btcDel.BtcUndelegation.SlashingTx.EncSign(
+			unbondingMsgTx,
+			0,
+			unbondingTxSlashingPathInfo.RevealedLeaf.Script,
+			stm.CovenantPrivKeys[0],
+			v,
+		)
+		require.NoError(t, err)
+		covenantAdaptorUnbondingSlashing1List = append(covenantAdaptorUnbondingSlashing1List, covenantAdaptorUnbondingSlashing1.MustMarshal())
+	}
 
-	_, err = tm.BBNClient.SubmitCovenantSigs(
-		tm.CovenantPrivKeys[0].PubKey(),
+	_, err = stm.BBNClient.SubmitCovenantSigs(
+		stm.CovenantPrivKeys[0].PubKey(),
 		stakingMsgTx.TxHash().String(),
-		[][]byte{covenantAdaptorStakingSlashing1.MustMarshal()},
+		covenantAdaptorStakingSlashing1List,
 		covenantUnbondingSig1,
-		[][]byte{covenantAdaptorUnbondingSlashing1.MustMarshal()},
+		covenantAdaptorUnbondingSlashing1List,
 	)
 	require.NoError(t, err)
 
-	// Covenant 1 signatures
-	covenantAdaptorStakingSlashing2, err := slashingTx.EncSign(
-		stakingMsgTx,
-		idx,
-		slashingPathInfo.RevealedLeaf.Script,
-		tm.CovenantPrivKeys[1],
-		valEncKey,
-	)
-	require.NoError(t, err)
+	var covenantAdaptorStakingSlashing2List [][]byte
+	for _, v := range valEncKeys {
+		// Covenant 1 signatures
+		covenantAdaptorStakingSlashing2, err := slashingTx.EncSign(
+			stakingMsgTx,
+			idx,
+			slashingPathInfo.RevealedLeaf.Script,
+			stm.CovenantPrivKeys[1],
+			v,
+		)
+		require.NoError(t, err)
+		covenantAdaptorStakingSlashing2List = append(covenantAdaptorStakingSlashing2List, covenantAdaptorStakingSlashing2.MustMarshal())
+	}
+
 	covenantUnbondingSig2, err := btcstaking.SignTxWithOneScriptSpendInputFromTapLeaf(
 		unbondingMsgTx,
 		stakingInfo.StakingOutput,
-		tm.CovenantPrivKeys[1],
+		stm.CovenantPrivKeys[1],
 		stakingTxUnbondingPathInfo.RevealedLeaf,
 	)
 	require.NoError(t, err)
 
-	// slashing unbonding tx sig
+	var covenantAdaptorUnbondingSlashing2List [][]byte
+	for _, v := range valEncKeys {
+		// slashing unbonding tx sig
+		unbondingTxSlashingPathInfo, err := unbondingInfo.SlashingPathSpendInfo()
+		require.NoError(t, err)
+		covenantAdaptorUnbondingSlashing2, err := btcDel.BtcUndelegation.SlashingTx.EncSign(
+			unbondingMsgTx,
+			0,
+			unbondingTxSlashingPathInfo.RevealedLeaf.Script,
+			stm.CovenantPrivKeys[1],
+			v,
+		)
+		require.NoError(t, err)
+		covenantAdaptorUnbondingSlashing2List = append(covenantAdaptorUnbondingSlashing2List, covenantAdaptorUnbondingSlashing2.MustMarshal())
+	}
 
-	covenantAdaptorUnbondingSlashing2, err := btcDel.BtcUndelegation.SlashingTx.EncSign(
-		unbondingMsgTx,
-		0,
-		unbondingTxSlashingPathInfo.RevealedLeaf.Script,
-		tm.CovenantPrivKeys[1],
-		valEncKey,
-	)
-
-	require.NoError(t, err)
-	_, err = tm.BBNClient.SubmitCovenantSigs(
-		tm.CovenantPrivKeys[1].PubKey(),
+	_, err = stm.BBNClient.SubmitCovenantSigs(
+		stm.CovenantPrivKeys[1].PubKey(),
 		stakingMsgTx.TxHash().String(),
-		[][]byte{covenantAdaptorStakingSlashing2.MustMarshal()},
+		covenantAdaptorStakingSlashing2List,
 		covenantUnbondingSig2,
-		[][]byte{covenantAdaptorUnbondingSlashing2.MustMarshal()},
+		covenantAdaptorUnbondingSlashing2List,
 	)
 	require.NoError(t, err)
 }

--- a/itest/opstackl2/op_e2e_test.go
+++ b/itest/opstackl2/op_e2e_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/babylonchain/babylon/testutil/datagen"
+	e2eutils "github.com/babylonchain/finality-provider/itest"
 	"github.com/babylonchain/finality-provider/types"
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"github.com/stretchr/testify/require"
@@ -22,7 +23,7 @@ func TestOpSubmitFinalitySignature(t *testing.T) {
 	fpList := ctm.StartFinalityProvider(t, false, 1)
 	fpInstance := fpList[0]
 
-	ctm.WaitForFpPubRandCommitted(t, fpInstance)
+	e2eutils.WaitForFpPubRandCommitted(t, fpInstance)
 
 	// query pub rand
 	committedPubRandMap, err := ctm.OpL2ConsumerCtrl.QueryLastCommittedPublicRand(fpInstance.GetBtcPk(), 1)

--- a/itest/opstackl2/op_test_manager.go
+++ b/itest/opstackl2/op_test_manager.go
@@ -269,18 +269,6 @@ func (ctm *OpL2ConsumerTestManager) StartFinalityProvider(t *testing.T, isBabylo
 	return resFpList
 }
 
-func (ctm *OpL2ConsumerTestManager) WaitForFpPubRandCommitted(t *testing.T, fpIns *service.FinalityProviderInstance) {
-	require.Eventually(t, func() bool {
-		lastCommittedHeight, err := fpIns.GetLastCommittedHeight()
-		if err != nil {
-			return false
-		}
-		return lastCommittedHeight > 0
-	}, e2eutils.EventuallyWaitTimeOut, e2eutils.EventuallyPollTime)
-
-	t.Logf("Public randomness is successfully committed")
-}
-
 func storeWasmCode(opcc *opstackl2.OPStackL2ConsumerController, wasmFile string) error {
 	wasmCode, err := os.ReadFile(wasmFile)
 	if err != nil {

--- a/itest/utils.go
+++ b/itest/utils.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/babylonchain/babylon/types"
 	"github.com/babylonchain/finality-provider/finality-provider/config"
+	"github.com/babylonchain/finality-provider/finality-provider/service"
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/chaincfg"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
@@ -77,6 +78,18 @@ func GenerateCovenantCommittee(numCovenants int, t *testing.T) ([]*btcec.Private
 	}
 
 	return covenantPrivKeys, covenantPubKeys
+}
+
+func WaitForFpPubRandCommitted(t *testing.T, fpIns *service.FinalityProviderInstance) {
+	require.Eventually(t, func() bool {
+		lastCommittedHeight, err := fpIns.GetLastCommittedHeight()
+		if err != nil {
+			return false
+		}
+		return lastCommittedHeight > 0
+	}, EventuallyWaitTimeOut, EventuallyPollTime)
+
+	t.Logf("Public randomness is successfully committed")
 }
 
 func DefaultFpConfig(keyringDir, homeDir string) *config.Config {


### PR DESCRIPTION
## Summary

no need to define twice in both the OP and BBN test manager

## Test Plan

wait for CI