### PR TITLE
refactor: clean up interface `QueryLastCommittedPublicRand()`

### DIFF
--- a/clientcontroller/api/interface.go
+++ b/clientcontroller/api/interface.go
@@ -52,7 +52,7 @@ type ConsumerController interface {
 	QueryLatestFinalizedBlock() (*types.BlockInfo, error)
 
 	// QueryLastCommittedPublicRand returns the last committed public randomness
-	QueryLastCommittedPublicRand(fpPk *btcec.PublicKey, count uint64) (map[uint64]*types.PubRandCommit, error)
+	QueryLastCommittedPublicRand(fpPk *btcec.PublicKey) (*types.PubRandCommit, error)
 
 	// QueryBlock queries the block at the given height
 	QueryBlock(height uint64) (*types.BlockInfo, error)

--- a/clientcontroller/api/interface.go
+++ b/clientcontroller/api/interface.go
@@ -51,8 +51,8 @@ type ConsumerController interface {
 	// Note: nil will be returned if the finalized block does not exist
 	QueryLatestFinalizedBlock() (*types.BlockInfo, error)
 
-	// QueryLastCommittedPublicRand returns the last committed public randomness
-	QueryLastCommittedPublicRand(fpPk *btcec.PublicKey) (*types.PubRandCommit, error)
+	// QueryLastPublicRandCommit returns the last committed public randomness
+	QueryLastPublicRandCommit(fpPk *btcec.PublicKey) (*types.PubRandCommit, error)
 
 	// QueryBlock queries the block at the given height
 	QueryBlock(height uint64) (*types.BlockInfo, error)

--- a/clientcontroller/babylon/consumer.go
+++ b/clientcontroller/babylon/consumer.go
@@ -297,16 +297,21 @@ func (bc *BabylonConsumerController) QueryLastCommittedPublicRand(fpPk *btcec.Pu
 		return nil, fmt.Errorf("failed to query committed public randomness: %w", err)
 	}
 
-	var commit types.PubRandCommit
+	if len(res.PubRandCommitMap) != 1 {
+		// before first PR commitment, it's expected to return nothing
+		return nil, nil
+	}
+
+	var commit *types.PubRandCommit
 	for height, commitRes := range res.PubRandCommitMap {
-		commit = types.PubRandCommit{
+		commit = &types.PubRandCommit{
 			StartHeight: height,
 			NumPubRand:  commitRes.NumPubRand,
 			Commitment:  commitRes.Commitment,
 		}
 	}
 
-	return &commit, nil
+	return commit, nil
 }
 
 func (bc *BabylonConsumerController) QueryIsBlockFinalized(height uint64) (bool, error) {

--- a/clientcontroller/babylon/consumer.go
+++ b/clientcontroller/babylon/consumer.go
@@ -298,7 +298,7 @@ func (bc *BabylonConsumerController) QueryLastCommittedPublicRand(fpPk *btcec.Pu
 	}
 
 	if len(res.PubRandCommitMap) > 1 {
-		return nil, fmt.Errorf("expected length to be 1, but got :%d", len(res.PubRandCommitMap))
+		return nil, fmt.Errorf("expected length to be 1, but get :%d", len(res.PubRandCommitMap))
 	}
 
 	var commit *types.PubRandCommit

--- a/clientcontroller/babylon/consumer.go
+++ b/clientcontroller/babylon/consumer.go
@@ -297,11 +297,16 @@ func (bc *BabylonConsumerController) QueryLastCommittedPublicRand(fpPk *btcec.Pu
 		return nil, fmt.Errorf("failed to query committed public randomness: %w", err)
 	}
 
+	if len(res.PubRandCommitMap) == 0 {
+		// expected when there is no PR commit at all
+		return nil, nil
+	}
+
 	if len(res.PubRandCommitMap) > 1 {
 		return nil, fmt.Errorf("expected length to be 1, but get :%d", len(res.PubRandCommitMap))
 	}
 
-	var commit *types.PubRandCommit
+	var commit *types.PubRandCommit = nil
 	for height, commitRes := range res.PubRandCommitMap {
 		commit = &types.PubRandCommit{
 			StartHeight: height,

--- a/clientcontroller/babylon/consumer.go
+++ b/clientcontroller/babylon/consumer.go
@@ -283,8 +283,8 @@ func (bc *BabylonConsumerController) QueryBlock(height uint64) (*types.BlockInfo
 	}, nil
 }
 
-// QueryLastCommittedPublicRand returns the last public randomness commitments
-func (bc *BabylonConsumerController) QueryLastCommittedPublicRand(fpPk *btcec.PublicKey) (*types.PubRandCommit, error) {
+// QueryLastPublicRandCommit returns the last public randomness commitments
+func (bc *BabylonConsumerController) QueryLastPublicRandCommit(fpPk *btcec.PublicKey) (*types.PubRandCommit, error) {
 	fpBtcPk := bbntypes.NewBIP340PubKeyFromBTCPK(fpPk)
 
 	pagination := &sdkquery.PageRequest{

--- a/clientcontroller/babylon/consumer.go
+++ b/clientcontroller/babylon/consumer.go
@@ -297,9 +297,8 @@ func (bc *BabylonConsumerController) QueryLastCommittedPublicRand(fpPk *btcec.Pu
 		return nil, fmt.Errorf("failed to query committed public randomness: %w", err)
 	}
 
-	if len(res.PubRandCommitMap) != 1 {
-		// before first PR commitment, it's expected to return nothing
-		return nil, nil
+	if len(res.PubRandCommitMap) > 1 {
+		return nil, fmt.Errorf("expected length to be 1, but got :%d", len(res.PubRandCommitMap))
 	}
 
 	var commit *types.PubRandCommit

--- a/clientcontroller/cosmwasm/consumer.go
+++ b/clientcontroller/cosmwasm/consumer.go
@@ -421,12 +421,19 @@ func (wc *CosmwasmConsumerController) QueryLastCommittedPublicRand(fpPk *btcec.P
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
+	if len(commits) == 0 {
+		// expected when there is no PR commit at all
+		// `get_pub_rand_commit`'s return type is Vec<PubRandCommit> and it can be
+		// empty vector if no results found
+		return nil, nil
+	}
+
 	if len(commits) > 1 {
 		return nil, fmt.Errorf("expected length to be 1, but got :%d", len(commits))
 	}
 
 	// Convert the response to the expected map format
-	var commit *fptypes.PubRandCommit
+	var commit *fptypes.PubRandCommit = nil
 	for _, commitRes := range commits {
 		commitCopy := commitRes // create a copy to avoid referencing the loop variable
 		commit = &fptypes.PubRandCommit{

--- a/clientcontroller/cosmwasm/consumer.go
+++ b/clientcontroller/cosmwasm/consumer.go
@@ -391,10 +391,11 @@ func (wc *CosmwasmConsumerController) QueryBlock(height uint64) (*fptypes.BlockI
 }
 
 // QueryLastCommittedPublicRand returns the last public randomness commitments
-func (wc *CosmwasmConsumerController) QueryLastCommittedPublicRand(fpPk *btcec.PublicKey, count uint64) (map[uint64]*fptypes.PubRandCommit, error) {
+func (wc *CosmwasmConsumerController) QueryLastCommittedPublicRand(fpPk *btcec.PublicKey) (*fptypes.PubRandCommit, error) {
 	fpBtcPk := bbntypes.NewBIP340PubKeyFromBTCPK(fpPk)
 
 	// Construct the query message
+	count := uint64(1)
 	queryMsgStruct := QueryMsgLastPubRandCommit{
 		LastPubRandCommit: LastPubRandCommitQuery{
 			BtcPkHex: fpBtcPk.MarshalHex(),
@@ -421,16 +422,17 @@ func (wc *CosmwasmConsumerController) QueryLastCommittedPublicRand(fpPk *btcec.P
 	}
 
 	// Convert the response to the expected map format
-	commitMap := make(map[uint64]*fptypes.PubRandCommit)
-	for _, commit := range commits {
-		commitCopy := commit // create a copy to avoid referencing the loop variable
-		commitMap[commit.StartHeight] = &fptypes.PubRandCommit{
-			NumPubRand: commitCopy.NumPubRand,
-			Commitment: commitCopy.Commitment,
+	var commit *fptypes.PubRandCommit
+	for _, commitRes := range commits {
+		commitCopy := commitRes // create a copy to avoid referencing the loop variable
+		commit = &fptypes.PubRandCommit{
+			StartHeight: commitCopy.StartHeight,
+			NumPubRand:  commitCopy.NumPubRand,
+			Commitment:  commitCopy.Commitment,
 		}
 	}
 
-	return commitMap, nil
+	return commit, nil
 }
 
 func (wc *CosmwasmConsumerController) QueryIsBlockFinalized(height uint64) (bool, error) {

--- a/clientcontroller/cosmwasm/consumer.go
+++ b/clientcontroller/cosmwasm/consumer.go
@@ -390,8 +390,8 @@ func (wc *CosmwasmConsumerController) QueryBlock(height uint64) (*fptypes.BlockI
 	}, nil
 }
 
-// QueryLastCommittedPublicRand returns the last public randomness commitments
-func (wc *CosmwasmConsumerController) QueryLastCommittedPublicRand(fpPk *btcec.PublicKey) (*fptypes.PubRandCommit, error) {
+// QueryLastPublicRandCommit returns the last public randomness commitments
+func (wc *CosmwasmConsumerController) QueryLastPublicRandCommit(fpPk *btcec.PublicKey) (*fptypes.PubRandCommit, error) {
 	fpBtcPk := bbntypes.NewBIP340PubKeyFromBTCPK(fpPk)
 
 	// Construct the query message

--- a/clientcontroller/cosmwasm/consumer.go
+++ b/clientcontroller/cosmwasm/consumer.go
@@ -421,6 +421,10 @@ func (wc *CosmwasmConsumerController) QueryLastCommittedPublicRand(fpPk *btcec.P
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
+	if len(commits) > 1 {
+		return nil, fmt.Errorf("expected length to be 1, but got :%d", len(commits))
+	}
+
 	// Convert the response to the expected map format
 	var commit *fptypes.PubRandCommit
 	for _, commitRes := range commits {

--- a/clientcontroller/opstackl2/consumer.go
+++ b/clientcontroller/opstackl2/consumer.go
@@ -325,9 +325,9 @@ func (cc *OPStackL2ConsumerController) QueryLatestBlockHeight() (uint64, error) 
 	return l2LatestBlock.Number.Uint64(), nil
 }
 
-// QueryLastCommittedPublicRand returns the last public randomness commitments
+// QueryLastPublicRandCommit returns the last public randomness commitments
 // It is fetched from the state of a CosmWasm contract OP finality gadget.
-func (cc *OPStackL2ConsumerController) QueryLastCommittedPublicRand(fpPk *btcec.PublicKey) (*types.PubRandCommit, error) {
+func (cc *OPStackL2ConsumerController) QueryLastPublicRandCommit(fpPk *btcec.PublicKey) (*types.PubRandCommit, error) {
 	fpPubKey := bbntypes.NewBIP340PubKeyFromBTCPK(fpPk)
 	queryMsg := &QueryMsg{
 		LastPubRandCommit: &LastPubRandCommit{

--- a/clientcontroller/opstackl2/consumer.go
+++ b/clientcontroller/opstackl2/consumer.go
@@ -327,7 +327,7 @@ func (cc *OPStackL2ConsumerController) QueryLatestBlockHeight() (uint64, error) 
 
 // QueryLastCommittedPublicRand returns the last public randomness commitments
 // It is fetched from the state of a CosmWasm contract OP finality gadget.
-func (cc *OPStackL2ConsumerController) QueryLastCommittedPublicRand(fpPk *btcec.PublicKey, count uint64) (map[uint64]*types.PubRandCommit, error) {
+func (cc *OPStackL2ConsumerController) QueryLastCommittedPublicRand(fpPk *btcec.PublicKey) (*types.PubRandCommit, error) {
 	fpPubKey := bbntypes.NewBIP340PubKeyFromBTCPK(fpPk)
 	queryMsg := &QueryMsg{
 		LastPubRandCommit: &LastPubRandCommit{
@@ -351,18 +351,13 @@ func (cc *OPStackL2ConsumerController) QueryLastCommittedPublicRand(fpPk *btcec.
 		return nil, nil
 	}
 
-	var resp LastPubRandCommitResponse
+	var resp types.PubRandCommit
 	err = json.Unmarshal(stateResp.Data, &resp)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
-	respMap := make(map[uint64]*types.PubRandCommit)
-	respMap[resp.StartHeight] = &types.PubRandCommit{
-		NumPubRand: resp.NumPubRand,
-		Commitment: resp.Commitment,
-	}
 
-	return respMap, nil
+	return &resp, nil
 }
 
 func ConvertProof(cmtProof cmtcrypto.Proof) Proof {

--- a/clientcontroller/opstackl2/msg.go
+++ b/clientcontroller/opstackl2/msg.go
@@ -51,12 +51,6 @@ type ConfigResponse struct {
 	ActivatedHeight uint64 `json:"activated_height"`
 }
 
-type LastPubRandCommitResponse struct {
-	StartHeight uint64 `json:"start_height"`
-	NumPubRand  uint64 `json:"num_pub_rand"`
-	Commitment  []byte `json:"commitment"`
-}
-
 type Proof struct {
 	Total    uint64   `json:"total"`
 	Index    uint64   `json:"index"`

--- a/finality-provider/service/app_test.go
+++ b/finality-provider/service/app_test.go
@@ -112,7 +112,7 @@ func FuzzRegisterFinalityProvider(f *testing.F) {
 		require.NoError(t, err)
 		require.Equal(t, txHash, res.TxHash)
 
-		mockConsumerController.EXPECT().QueryLastCommittedPublicRand(gomock.Any()).Return(nil, nil).AnyTimes()
+		mockConsumerController.EXPECT().QueryLastPublicRandCommit(gomock.Any()).Return(nil, nil).AnyTimes()
 		err = app.StartHandlingFinalityProvider(fp.GetBIP340BTCPK(), passphrase)
 		require.NoError(t, err)
 

--- a/finality-provider/service/app_test.go
+++ b/finality-provider/service/app_test.go
@@ -112,7 +112,7 @@ func FuzzRegisterFinalityProvider(f *testing.F) {
 		require.NoError(t, err)
 		require.Equal(t, txHash, res.TxHash)
 
-		mockConsumerController.EXPECT().QueryLastCommittedPublicRand(gomock.Any(), uint64(1)).Return(nil, nil).AnyTimes()
+		mockConsumerController.EXPECT().QueryLastCommittedPublicRand(gomock.Any()).Return(nil, nil).AnyTimes()
 		err = app.StartHandlingFinalityProvider(fp.GetBIP340BTCPK(), passphrase)
 		require.NoError(t, err)
 

--- a/finality-provider/service/fastsync_test.go
+++ b/finality-provider/service/fastsync_test.go
@@ -41,12 +41,12 @@ func FuzzFastSync_SufficientRandomness(f *testing.F) {
 		// the last committed height is higher than the current height
 		// to make sure the randomness is sufficient
 		lastCommittedHeight := randomStartingHeight + testutil.TestPubRandNum
-		lastCommittedPubRandMap := make(map[uint64]*types.PubRandCommit)
-		lastCommittedPubRandMap[lastCommittedHeight] = &types.PubRandCommit{
-			NumPubRand: 1000,
-			Commitment: datagen.GenRandomByteArray(r, 32),
+		lastCommittedPubRand := &types.PubRandCommit{
+			StartHeight: lastCommittedHeight,
+			NumPubRand:  1000,
+			Commitment:  datagen.GenRandomByteArray(r, 32),
 		}
-		mockConsumerController.EXPECT().QueryLastCommittedPublicRand(gomock.Any()).Return(lastCommittedPubRandMap, nil).AnyTimes()
+		mockConsumerController.EXPECT().QueryLastCommittedPublicRand(gomock.Any()).Return(lastCommittedPubRand, nil).AnyTimes()
 
 		catchUpBlocks := testutil.GenBlocks(r, finalizedHeight+1, currentHeight)
 		expectedTxHash := testutil.GenRandomHexStr(r, 32)
@@ -93,12 +93,12 @@ func FuzzFastSync_NoRandomness(f *testing.F) {
 			Return(uint64(1), nil).AnyTimes()
 		// the last height with pub rand is a random value inside [finalizedHeight+1, currentHeight]
 		lastHeightWithPubRand := uint64(rand.Intn(int(currentHeight)-int(finalizedHeight))) + finalizedHeight + 1
-		lastCommittedPubRandMap := make(map[uint64]*types.PubRandCommit)
-		lastCommittedPubRandMap[lastHeightWithPubRand-10] = &types.PubRandCommit{
-			NumPubRand: 10 + 1,
-			Commitment: datagen.GenRandomByteArray(r, 32),
+		lastCommittedPubRand := &types.PubRandCommit{
+			StartHeight: lastHeightWithPubRand - 10,
+			NumPubRand:  10 + 1,
+			Commitment:  datagen.GenRandomByteArray(r, 32),
 		}
-		mockConsumerController.EXPECT().QueryLastCommittedPublicRand(gomock.Any()).Return(lastCommittedPubRandMap, nil).AnyTimes()
+		mockConsumerController.EXPECT().QueryLastCommittedPublicRand(gomock.Any()).Return(lastCommittedPubRand, nil).AnyTimes()
 
 		catchUpBlocks := testutil.GenBlocks(r, finalizedHeight+1, currentHeight)
 		expectedTxHash := testutil.GenRandomHexStr(r, 32)

--- a/finality-provider/service/fastsync_test.go
+++ b/finality-provider/service/fastsync_test.go
@@ -31,7 +31,7 @@ func FuzzFastSync_SufficientRandomness(f *testing.F) {
 		defer cleanUp()
 
 		// commit pub rand
-		mockConsumerController.EXPECT().QueryLastCommittedPublicRand(gomock.Any(), uint64(1)).Return(nil, nil).Times(1)
+		mockConsumerController.EXPECT().QueryLastCommittedPublicRand(gomock.Any()).Return(nil, nil).Times(1)
 		mockConsumerController.EXPECT().CommitPubRandList(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
 		_, err := fpIns.CommitPubRand(randomStartingHeight)
 		require.NoError(t, err)
@@ -46,7 +46,7 @@ func FuzzFastSync_SufficientRandomness(f *testing.F) {
 			NumPubRand: 1000,
 			Commitment: datagen.GenRandomByteArray(r, 32),
 		}
-		mockConsumerController.EXPECT().QueryLastCommittedPublicRand(gomock.Any(), uint64(1)).Return(lastCommittedPubRandMap, nil).AnyTimes()
+		mockConsumerController.EXPECT().QueryLastCommittedPublicRand(gomock.Any()).Return(lastCommittedPubRandMap, nil).AnyTimes()
 
 		catchUpBlocks := testutil.GenBlocks(r, finalizedHeight+1, currentHeight)
 		expectedTxHash := testutil.GenRandomHexStr(r, 32)
@@ -84,7 +84,7 @@ func FuzzFastSync_NoRandomness(f *testing.F) {
 		defer cleanUp()
 
 		// commit pub rand
-		mockConsumerController.EXPECT().QueryLastCommittedPublicRand(gomock.Any(), uint64(1)).Return(nil, nil).Times(1)
+		mockConsumerController.EXPECT().QueryLastCommittedPublicRand(gomock.Any()).Return(nil, nil).Times(1)
 		mockConsumerController.EXPECT().CommitPubRandList(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
 		_, err := fpIns.CommitPubRand(randomStartingHeight)
 		require.NoError(t, err)
@@ -98,7 +98,7 @@ func FuzzFastSync_NoRandomness(f *testing.F) {
 			NumPubRand: 10 + 1,
 			Commitment: datagen.GenRandomByteArray(r, 32),
 		}
-		mockConsumerController.EXPECT().QueryLastCommittedPublicRand(gomock.Any(), uint64(1)).Return(lastCommittedPubRandMap, nil).AnyTimes()
+		mockConsumerController.EXPECT().QueryLastCommittedPublicRand(gomock.Any()).Return(lastCommittedPubRandMap, nil).AnyTimes()
 
 		catchUpBlocks := testutil.GenBlocks(r, finalizedHeight+1, currentHeight)
 		expectedTxHash := testutil.GenRandomHexStr(r, 32)

--- a/finality-provider/service/fastsync_test.go
+++ b/finality-provider/service/fastsync_test.go
@@ -31,7 +31,7 @@ func FuzzFastSync_SufficientRandomness(f *testing.F) {
 		defer cleanUp()
 
 		// commit pub rand
-		mockConsumerController.EXPECT().QueryLastCommittedPublicRand(gomock.Any()).Return(nil, nil).Times(1)
+		mockConsumerController.EXPECT().QueryLastPublicRandCommit(gomock.Any()).Return(nil, nil).Times(1)
 		mockConsumerController.EXPECT().CommitPubRandList(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
 		_, err := fpIns.CommitPubRand(randomStartingHeight)
 		require.NoError(t, err)
@@ -46,7 +46,7 @@ func FuzzFastSync_SufficientRandomness(f *testing.F) {
 			NumPubRand:  1000,
 			Commitment:  datagen.GenRandomByteArray(r, 32),
 		}
-		mockConsumerController.EXPECT().QueryLastCommittedPublicRand(gomock.Any()).Return(lastCommittedPubRand, nil).AnyTimes()
+		mockConsumerController.EXPECT().QueryLastPublicRandCommit(gomock.Any()).Return(lastCommittedPubRand, nil).AnyTimes()
 
 		catchUpBlocks := testutil.GenBlocks(r, finalizedHeight+1, currentHeight)
 		expectedTxHash := testutil.GenRandomHexStr(r, 32)
@@ -84,7 +84,7 @@ func FuzzFastSync_NoRandomness(f *testing.F) {
 		defer cleanUp()
 
 		// commit pub rand
-		mockConsumerController.EXPECT().QueryLastCommittedPublicRand(gomock.Any()).Return(nil, nil).Times(1)
+		mockConsumerController.EXPECT().QueryLastPublicRandCommit(gomock.Any()).Return(nil, nil).Times(1)
 		mockConsumerController.EXPECT().CommitPubRandList(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
 		_, err := fpIns.CommitPubRand(randomStartingHeight)
 		require.NoError(t, err)
@@ -98,7 +98,7 @@ func FuzzFastSync_NoRandomness(f *testing.F) {
 			NumPubRand:  10 + 1,
 			Commitment:  datagen.GenRandomByteArray(r, 32),
 		}
-		mockConsumerController.EXPECT().QueryLastCommittedPublicRand(gomock.Any()).Return(lastCommittedPubRand, nil).AnyTimes()
+		mockConsumerController.EXPECT().QueryLastPublicRandCommit(gomock.Any()).Return(lastCommittedPubRand, nil).AnyTimes()
 
 		catchUpBlocks := testutil.GenBlocks(r, finalizedHeight+1, currentHeight)
 		expectedTxHash := testutil.GenRandomHexStr(r, 32)

--- a/finality-provider/service/fp_instance.go
+++ b/finality-provider/service/fp_instance.go
@@ -897,8 +897,12 @@ func (fp *FinalityProviderInstance) GetLastCommittedHeight() (uint64, error) {
 	}
 
 	// no committed randomness yet
-	if pubRandCommit == nil {
+	if pubRandCommit == nil || (pubRandCommit.StartHeight == 0 && pubRandCommit.NumPubRand == 0) {
 		return 0, nil
+	}
+
+	if pubRandCommit.NumPubRand == 0 {
+		return 0, errors.New("the field NumPubRand should always be at least one")
 	}
 
 	lastCommittedHeight := pubRandCommit.StartHeight + pubRandCommit.NumPubRand - 1

--- a/finality-provider/service/fp_instance.go
+++ b/finality-provider/service/fp_instance.go
@@ -913,7 +913,7 @@ func (fp *FinalityProviderInstance) GetLastCommittedHeight() (uint64, error) {
 func (fp *FinalityProviderInstance) lastCommittedPublicRandWithRetry() (*types.PubRandCommit, error) {
 	var response *types.PubRandCommit
 	if err := retry.Do(func() error {
-		resp, err := fp.consumerCon.QueryLastCommittedPublicRand(fp.GetBtcPk())
+		resp, err := fp.consumerCon.QueryLastPublicRandCommit(fp.GetBtcPk())
 		if err != nil {
 			return err
 		}

--- a/finality-provider/service/fp_instance.go
+++ b/finality-provider/service/fp_instance.go
@@ -897,12 +897,8 @@ func (fp *FinalityProviderInstance) GetLastCommittedHeight() (uint64, error) {
 	}
 
 	// no committed randomness yet
-	if pubRandCommit == nil || (pubRandCommit.StartHeight == 0 && pubRandCommit.NumPubRand == 0) {
+	if pubRandCommit == nil {
 		return 0, nil
-	}
-
-	if pubRandCommit.NumPubRand == 0 {
-		return 0, errors.New("the field NumPubRand should always be at least one")
 	}
 
 	lastCommittedHeight := pubRandCommit.StartHeight + pubRandCommit.NumPubRand - 1
@@ -916,6 +912,11 @@ func (fp *FinalityProviderInstance) lastCommittedPublicRandWithRetry() (*types.P
 		resp, err := fp.consumerCon.QueryLastPublicRandCommit(fp.GetBtcPk())
 		if err != nil {
 			return err
+		}
+		if resp != nil {
+			if err := resp.Validate(); err != nil {
+				return err
+			}
 		}
 		response = resp
 		return nil

--- a/finality-provider/service/fp_instance_test.go
+++ b/finality-provider/service/fp_instance_test.go
@@ -41,7 +41,7 @@ func FuzzCommitPubRandList(f *testing.F) {
 		mockConsumerController.EXPECT().
 			CommitPubRandList(fpIns.GetBtcPk(), startingBlock.Height+1, gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(&types.TxResponse{TxHash: expectedTxHash}, nil).AnyTimes()
-		mockConsumerController.EXPECT().QueryLastCommittedPublicRand(gomock.Any()).Return(nil, nil).AnyTimes()
+		mockConsumerController.EXPECT().QueryLastPublicRandCommit(gomock.Any()).Return(nil, nil).AnyTimes()
 		res, err := fpIns.CommitPubRand(startingBlock.Height)
 		require.NoError(t, err)
 		require.Equal(t, expectedTxHash, res.TxHash)
@@ -64,7 +64,7 @@ func FuzzSubmitFinalitySig(f *testing.F) {
 		defer cleanUp()
 
 		// commit pub rand
-		mockConsumerController.EXPECT().QueryLastCommittedPublicRand(gomock.Any()).Return(nil, nil).Times(1)
+		mockConsumerController.EXPECT().QueryLastPublicRandCommit(gomock.Any()).Return(nil, nil).Times(1)
 		mockConsumerController.EXPECT().CommitPubRandList(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
 		_, err := fpIns.CommitPubRand(startingBlock.Height)
 		require.NoError(t, err)
@@ -76,7 +76,7 @@ func FuzzSubmitFinalitySig(f *testing.F) {
 			NumPubRand:  1000,
 			Commitment:  datagen.GenRandomByteArray(r, 32),
 		}
-		mockConsumerController.EXPECT().QueryLastCommittedPublicRand(gomock.Any()).Return(lastCommittedPubRand, nil).AnyTimes()
+		mockConsumerController.EXPECT().QueryLastPublicRandCommit(gomock.Any()).Return(lastCommittedPubRand, nil).AnyTimes()
 		// mock voting power and commit pub rand
 		mockConsumerController.EXPECT().QueryFinalityProviderVotingPower(fpIns.GetBtcPk(), gomock.Any()).
 			Return(uint64(1), nil).AnyTimes()

--- a/finality-provider/service/fp_instance_test.go
+++ b/finality-provider/service/fp_instance_test.go
@@ -41,7 +41,7 @@ func FuzzCommitPubRandList(f *testing.F) {
 		mockConsumerController.EXPECT().
 			CommitPubRandList(fpIns.GetBtcPk(), startingBlock.Height+1, gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(&types.TxResponse{TxHash: expectedTxHash}, nil).AnyTimes()
-		mockConsumerController.EXPECT().QueryLastCommittedPublicRand(gomock.Any(), uint64(1)).Return(nil, nil).AnyTimes()
+		mockConsumerController.EXPECT().QueryLastCommittedPublicRand(gomock.Any()).Return(nil, nil).AnyTimes()
 		res, err := fpIns.CommitPubRand(startingBlock.Height)
 		require.NoError(t, err)
 		require.Equal(t, expectedTxHash, res.TxHash)
@@ -64,7 +64,7 @@ func FuzzSubmitFinalitySig(f *testing.F) {
 		defer cleanUp()
 
 		// commit pub rand
-		mockConsumerController.EXPECT().QueryLastCommittedPublicRand(gomock.Any(), uint64(1)).Return(nil, nil).Times(1)
+		mockConsumerController.EXPECT().QueryLastCommittedPublicRand(gomock.Any()).Return(nil, nil).Times(1)
 		mockConsumerController.EXPECT().CommitPubRandList(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
 		_, err := fpIns.CommitPubRand(startingBlock.Height)
 		require.NoError(t, err)
@@ -76,7 +76,7 @@ func FuzzSubmitFinalitySig(f *testing.F) {
 			NumPubRand: 1000,
 			Commitment: datagen.GenRandomByteArray(r, 32),
 		}
-		mockConsumerController.EXPECT().QueryLastCommittedPublicRand(gomock.Any(), uint64(1)).Return(lastCommittedPubRandMap, nil).AnyTimes()
+		mockConsumerController.EXPECT().QueryLastCommittedPublicRand(gomock.Any()).Return(lastCommittedPubRandMap, nil).AnyTimes()
 		// mock voting power and commit pub rand
 		mockConsumerController.EXPECT().QueryFinalityProviderVotingPower(fpIns.GetBtcPk(), gomock.Any()).
 			Return(uint64(1), nil).AnyTimes()

--- a/finality-provider/service/fp_instance_test.go
+++ b/finality-provider/service/fp_instance_test.go
@@ -71,12 +71,12 @@ func FuzzSubmitFinalitySig(f *testing.F) {
 
 		// mock committed pub rand
 		lastCommittedHeight := randomStartingHeight + 25
-		lastCommittedPubRandMap := make(map[uint64]*types.PubRandCommit)
-		lastCommittedPubRandMap[lastCommittedHeight] = &types.PubRandCommit{
-			NumPubRand: 1000,
-			Commitment: datagen.GenRandomByteArray(r, 32),
+		lastCommittedPubRand := &types.PubRandCommit{
+			StartHeight: lastCommittedHeight,
+			NumPubRand:  1000,
+			Commitment:  datagen.GenRandomByteArray(r, 32),
 		}
-		mockConsumerController.EXPECT().QueryLastCommittedPublicRand(gomock.Any()).Return(lastCommittedPubRandMap, nil).AnyTimes()
+		mockConsumerController.EXPECT().QueryLastCommittedPublicRand(gomock.Any()).Return(lastCommittedPubRand, nil).AnyTimes()
 		// mock voting power and commit pub rand
 		mockConsumerController.EXPECT().QueryFinalityProviderVotingPower(fpIns.GetBtcPk(), gomock.Any()).
 			Return(uint64(1), nil).AnyTimes()

--- a/finality-provider/service/fp_manager_test.go
+++ b/finality-provider/service/fp_manager_test.go
@@ -57,7 +57,7 @@ func FuzzStatusUpdate(f *testing.F) {
 		mockConsumerController.EXPECT().QueryLatestBlockHeight().Return(currentHeight, nil).AnyTimes()
 		mockConsumerController.EXPECT().QueryActivatedHeight().Return(uint64(1), nil).AnyTimes()
 		mockConsumerController.EXPECT().QueryBlock(gomock.Any()).Return(currentBlockRes, nil).AnyTimes()
-		mockConsumerController.EXPECT().QueryLastCommittedPublicRand(gomock.Any()).Return(nil, nil).AnyTimes()
+		mockConsumerController.EXPECT().QueryLastPublicRandCommit(gomock.Any()).Return(nil, nil).AnyTimes()
 
 		votingPower := uint64(r.Intn(2))
 		mockConsumerController.EXPECT().QueryFinalityProviderVotingPower(gomock.Any(), currentHeight).Return(votingPower, nil).AnyTimes()

--- a/finality-provider/service/fp_manager_test.go
+++ b/finality-provider/service/fp_manager_test.go
@@ -57,7 +57,7 @@ func FuzzStatusUpdate(f *testing.F) {
 		mockConsumerController.EXPECT().QueryLatestBlockHeight().Return(currentHeight, nil).AnyTimes()
 		mockConsumerController.EXPECT().QueryActivatedHeight().Return(uint64(1), nil).AnyTimes()
 		mockConsumerController.EXPECT().QueryBlock(gomock.Any()).Return(currentBlockRes, nil).AnyTimes()
-		mockConsumerController.EXPECT().QueryLastCommittedPublicRand(gomock.Any(), uint64(1)).Return(nil, nil).AnyTimes()
+		mockConsumerController.EXPECT().QueryLastCommittedPublicRand(gomock.Any()).Return(nil, nil).AnyTimes()
 
 		votingPower := uint64(r.Intn(2))
 		mockConsumerController.EXPECT().QueryFinalityProviderVotingPower(gomock.Any(), currentHeight).Return(votingPower, nil).AnyTimes()

--- a/itest/babylon/babylon_e2e_test.go
+++ b/itest/babylon/babylon_e2e_test.go
@@ -28,7 +28,7 @@ func TestFinalityProviderLifeCycle(t *testing.T) {
 	fpIns := fpInsList[0]
 
 	// check the public randomness is committed
-	e2eutils.WaitForFpPubRandCommitted(t, fpIns)
+	e2eutils.WaitForFpPubRandCommitted(t, fpIns, 1)
 
 	// send a BTC delegation
 	_ = tm.InsertBTCDelegation(t, []*btcec.PublicKey{fpIns.GetBtcPk()}, e2eutils.StakingTime, e2eutils.StakingAmount)
@@ -60,7 +60,7 @@ func TestDoubleSigning(t *testing.T) {
 	fpIns := fpInsList[0]
 
 	// check the public randomness is committed
-	e2eutils.WaitForFpPubRandCommitted(t, fpIns)
+	e2eutils.WaitForFpPubRandCommitted(t, fpIns, 1)
 
 	// send a BTC delegation
 	_ = tm.InsertBTCDelegation(t, []*btcec.PublicKey{fpIns.GetBtcPk()}, e2eutils.StakingTime, e2eutils.StakingAmount)
@@ -119,7 +119,7 @@ func TestMultipleFinalityProviders(t *testing.T) {
 	// submit BTC delegations for each finality-provider
 	for _, fpi := range fpInstances {
 		// check the public randomness is committed
-		e2eutils.WaitForFpPubRandCommitted(t, fpi)
+		e2eutils.WaitForFpPubRandCommitted(t, fpi, 1)
 		// send a BTC delegation
 		_ = tm.InsertBTCDelegation(t, []*btcec.PublicKey{fpi.GetBtcPk()}, e2eutils.StakingTime, e2eutils.StakingAmount)
 	}
@@ -151,7 +151,7 @@ func TestFastSync(t *testing.T) {
 	fpIns := fpInsList[0]
 
 	// check the public randomness is committed
-	e2eutils.WaitForFpPubRandCommitted(t, fpIns)
+	e2eutils.WaitForFpPubRandCommitted(t, fpIns, 1)
 
 	// send a BTC delegation
 	_ = tm.InsertBTCDelegation(t, []*btcec.PublicKey{fpIns.GetBtcPk()}, e2eutils.StakingTime, e2eutils.StakingAmount)

--- a/itest/cosmwasm/bcd/bcd_consumer_e2e_test.go
+++ b/itest/cosmwasm/bcd/bcd_consumer_e2e_test.go
@@ -168,7 +168,7 @@ func TestConsumerFpLifecycle(t *testing.T) {
 
 	// ensure pub rand is submitted to smart contract
 	require.Eventually(t, func() bool {
-		fpPubRandResp, err := ctm.BcdConsumerClient.QueryLastCommittedPublicRand(fpPk.MustToBTCPK())
+		fpPubRandResp, err := ctm.BcdConsumerClient.QueryLastPublicRandCommit(fpPk.MustToBTCPK())
 		if err != nil {
 			t.Logf("failed to query last committed public rand: %s", err.Error())
 			return false

--- a/itest/cosmwasm/bcd/bcd_consumer_e2e_test.go
+++ b/itest/cosmwasm/bcd/bcd_consumer_e2e_test.go
@@ -168,7 +168,7 @@ func TestConsumerFpLifecycle(t *testing.T) {
 
 	// ensure pub rand is submitted to smart contract
 	require.Eventually(t, func() bool {
-		fpPubRandResp, err := ctm.BcdConsumerClient.QueryLastCommittedPublicRand(fpPk.MustToBTCPK(), 1)
+		fpPubRandResp, err := ctm.BcdConsumerClient.QueryLastCommittedPublicRand(fpPk.MustToBTCPK())
 		if err != nil {
 			t.Logf("failed to query last committed public rand: %s", err.Error())
 			return false

--- a/itest/opstackl2/op_e2e_test.go
+++ b/itest/opstackl2/op_e2e_test.go
@@ -29,13 +29,9 @@ func TestOpSubmitFinalitySignature(t *testing.T) {
 	e2eutils.WaitForFpPubRandCommitted(t, fpInstance)
 
 	// query pub rand
-	committedPubRandMap, err := ctm.OpL2ConsumerCtrl.QueryLastCommittedPublicRand(fpInstance.GetBtcPk(), 1)
+	committedPubRand, err := ctm.OpL2ConsumerCtrl.QueryLastCommittedPublicRand(fpInstance.GetBtcPk())
 	require.NoError(t, err)
-	var lastCommittedStartHeight uint64
-	for key := range committedPubRandMap {
-		lastCommittedStartHeight = key
-		break
-	}
+	lastCommittedStartHeight := committedPubRand.StartHeight
 	t.Logf("Last committed pubrandList startHeight %d", lastCommittedStartHeight)
 	pubRandList, err := fpInstance.GetPubRandList(lastCommittedStartHeight, ctm.FpConfig.NumPubRand)
 	require.NoError(t, err)
@@ -119,7 +115,6 @@ func TestBlockBabylonFinalized(t *testing.T) {
 	n := 1
 	fpList := ctm.StartFinalityProvider(t, false, n)
 
-	var lastCommittedStartHeight uint64
 	var mockHash []byte
 	// submit BTC delegations for each finality-provider
 	for _, fp := range fpList {
@@ -144,14 +139,12 @@ func TestBlockBabylonFinalized(t *testing.T) {
 	// check the BTC delegations are active
 	_ = ctm.WaitForNActiveDels(t, 1)
 
+	var lastCommittedStartHeight uint64
 	for _, fp := range fpList {
 		// query pub rand
-		committedPubRandMap, err := ctm.OpL2ConsumerCtrl.QueryLastCommittedPublicRand(fp.GetBtcPk(), 1)
+		committedPubRand, err := ctm.OpL2ConsumerCtrl.QueryLastCommittedPublicRand(fp.GetBtcPk())
 		require.NoError(t, err)
-		for key := range committedPubRandMap {
-			lastCommittedStartHeight = key
-			break
-		}
+		lastCommittedStartHeight = committedPubRand.StartHeight
 		t.Logf("Last committed pubrandList startHeight %d", lastCommittedStartHeight)
 
 		pubRandList, err := fp.GetPubRandList(lastCommittedStartHeight, ctm.FpConfig.NumPubRand)

--- a/itest/opstackl2/op_e2e_test.go
+++ b/itest/opstackl2/op_e2e_test.go
@@ -29,7 +29,7 @@ func TestOpSubmitFinalitySignature(t *testing.T) {
 	e2eutils.WaitForFpPubRandCommitted(t, fpInstance, 2)
 
 	// query pub rand
-	committedPubRand, err := ctm.OpL2ConsumerCtrl.QueryLastCommittedPublicRand(fpInstance.GetBtcPk())
+	committedPubRand, err := ctm.OpL2ConsumerCtrl.QueryLastPublicRandCommit(fpInstance.GetBtcPk())
 	require.NoError(t, err)
 	lastCommittedStartHeight := committedPubRand.StartHeight
 	t.Logf("Last committed pubrandList startHeight %d", lastCommittedStartHeight)
@@ -145,7 +145,7 @@ func TestBlockBabylonFinalized(t *testing.T) {
 	}
 	for _, fp := range fpList {
 		// query pub rand
-		committedPubRand, err := ctm.OpL2ConsumerCtrl.QueryLastCommittedPublicRand(fp.GetBtcPk())
+		committedPubRand, err := ctm.OpL2ConsumerCtrl.QueryLastPublicRandCommit(fp.GetBtcPk())
 		require.NoError(t, err)
 		lastCommittedStartHeight := committedPubRand.StartHeight
 		t.Logf("Last committed pubrandList startHeight %d", lastCommittedStartHeight)

--- a/itest/opstackl2/op_test_manager.go
+++ b/itest/opstackl2/op_test_manager.go
@@ -73,9 +73,9 @@ func StartOpL2ConsumerManager(t *testing.T) *OpL2ConsumerTestManager {
 	require.NoError(t, err)
 	fpHomeDir := filepath.Join(testDir, "fp-home")
 	cfg := e2eutils.DefaultFpConfig(bh.GetNodeDataDir(), fpHomeDir)
-	cfg.StatusUpdateInterval = 500 * time.Millisecond
-	cfg.RandomnessCommitInterval = 500 * time.Millisecond
-	cfg.FastSyncInterval = 1 * time.Second
+	cfg.StatusUpdateInterval = 2 * time.Second
+	cfg.RandomnessCommitInterval = 2 * time.Second
+	cfg.FastSyncInterval = 2 * time.Second
 	cfg.NumPubRand = 64
 	bc, err := bbncc.NewBabylonController(cfg.BabylonConfig, &cfg.BTCNetParams, logger)
 	require.NoError(t, err)

--- a/itest/opstackl2/op_test_manager.go
+++ b/itest/opstackl2/op_test_manager.go
@@ -38,6 +38,10 @@ import (
 const (
 	opFinalityGadgetContractPath = "../bytecode/op_finality_gadget_c6ccca8.wasm"
 	opConsumerId                 = "op-stack-l2-12345"
+	// it has to be a valid EVM RPC which doesn't timeout
+	opStackL2RPCAddress = "https://rpc.ankr.com/eth"
+	// it has to be a valid addr that can be passed into `sdktypes.AccAddressFromBech32()`
+	opFinalityGadgetAddress = "bbn1ghd753shjuwexxywmgs4xz7x2q732vcnkm6h2pyv9s6ah3hylvrqxxvh0f"
 )
 
 type BaseTestManager = base_test_manager.BaseTestManager
@@ -163,10 +167,8 @@ func mockOpL2ConsumerCtrlConfig(nodeDataDir string) *fpcfg.OPStackL2Config {
 
 	// fill up the config from dc config
 	return &fpcfg.OPStackL2Config{
-		// it has to be a valid EVM RPC which doesn't timeout
-		OPStackL2RPCAddress: "https://rpc.ankr.com/eth",
-		// it has to be a valid addr that can be passed into `sdktypes.AccAddressFromBech32()`
-		OPFinalityGadgetAddress: "bbn1ghd753shjuwexxywmgs4xz7x2q732vcnkm6h2pyv9s6ah3hylvrqxxvh0f",
+		OPStackL2RPCAddress:     opStackL2RPCAddress,
+		OPFinalityGadgetAddress: opFinalityGadgetAddress,
 		Key:                     dc.Key,
 		ChainID:                 dc.ChainID,
 		RPCAddr:                 dc.RPCAddr,

--- a/itest/utils.go
+++ b/itest/utils.go
@@ -84,14 +84,19 @@ func GenerateCovenantCommittee(numCovenants int, t *testing.T) ([]*btcec.Private
 	return covenantPrivKeys, covenantPubKeys
 }
 
-func WaitForFpPubRandCommitted(t *testing.T, fpIns *service.FinalityProviderInstance) {
+// n means expect n rounds of submissions
+func WaitForFpPubRandCommitted(t *testing.T, fpIns *service.FinalityProviderInstance, n int) {
+	count := 0
 	require.Eventually(t, func() bool {
 		lastCommittedHeight, err := fpIns.GetLastCommittedHeight()
 		if err != nil {
 			t.Errorf("Failed to fetch last committed height: %v", err)
 			return false
 		}
-		return lastCommittedHeight > 0
+		if lastCommittedHeight > 0 {
+			count++
+		}
+		return count >= n
 	}, EventuallyWaitTimeOut, EventuallyPollTime)
 
 	t.Logf("Public randomness is successfully committed")

--- a/itest/utils.go
+++ b/itest/utils.go
@@ -88,6 +88,7 @@ func WaitForFpPubRandCommitted(t *testing.T, fpIns *service.FinalityProviderInst
 	require.Eventually(t, func() bool {
 		lastCommittedHeight, err := fpIns.GetLastCommittedHeight()
 		if err != nil {
+			t.Errorf("Failed to fetch last committed height: %v", err)
 			return false
 		}
 		return lastCommittedHeight > 0

--- a/testutil/mocks/clientcontroller.go
+++ b/testutil/mocks/clientcontroller.go
@@ -209,18 +209,18 @@ func (mr *MockConsumerControllerMockRecorder) QueryIsBlockFinalized(height inter
 }
 
 // QueryLastCommittedPublicRand mocks base method.
-func (m *MockConsumerController) QueryLastCommittedPublicRand(fpPk *btcec.PublicKey, count uint64) (map[uint64]*types.PubRandCommit, error) {
+func (m *MockConsumerController) QueryLastCommittedPublicRand(fpPk *btcec.PublicKey) (*types.PubRandCommit, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "QueryLastCommittedPublicRand", fpPk, count)
-	ret0, _ := ret[0].(map[uint64]*types.PubRandCommit)
+	ret := m.ctrl.Call(m, "QueryLastCommittedPublicRand", fpPk)
+	ret0, _ := ret[0].(*types.PubRandCommit)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // QueryLastCommittedPublicRand indicates an expected call of QueryLastCommittedPublicRand.
-func (mr *MockConsumerControllerMockRecorder) QueryLastCommittedPublicRand(fpPk, count interface{}) *gomock.Call {
+func (mr *MockConsumerControllerMockRecorder) QueryLastCommittedPublicRand(fpPk interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryLastCommittedPublicRand", reflect.TypeOf((*MockConsumerController)(nil).QueryLastCommittedPublicRand), fpPk, count)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryLastCommittedPublicRand", reflect.TypeOf((*MockConsumerController)(nil).QueryLastCommittedPublicRand), fpPk)
 }
 
 // QueryLatestBlockHeight mocks base method.

--- a/testutil/mocks/clientcontroller.go
+++ b/testutil/mocks/clientcontroller.go
@@ -208,19 +208,19 @@ func (mr *MockConsumerControllerMockRecorder) QueryIsBlockFinalized(height inter
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryIsBlockFinalized", reflect.TypeOf((*MockConsumerController)(nil).QueryIsBlockFinalized), height)
 }
 
-// QueryLastCommittedPublicRand mocks base method.
-func (m *MockConsumerController) QueryLastCommittedPublicRand(fpPk *btcec.PublicKey) (*types.PubRandCommit, error) {
+// QueryLastPublicRandCommit mocks base method.
+func (m *MockConsumerController) QueryLastPublicRandCommit(fpPk *btcec.PublicKey) (*types.PubRandCommit, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "QueryLastCommittedPublicRand", fpPk)
+	ret := m.ctrl.Call(m, "QueryLastPublicRandCommit", fpPk)
 	ret0, _ := ret[0].(*types.PubRandCommit)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// QueryLastCommittedPublicRand indicates an expected call of QueryLastCommittedPublicRand.
-func (mr *MockConsumerControllerMockRecorder) QueryLastCommittedPublicRand(fpPk interface{}) *gomock.Call {
+// QueryLastPublicRandCommit indicates an expected call of QueryLastPublicRandCommit.
+func (mr *MockConsumerControllerMockRecorder) QueryLastPublicRandCommit(fpPk interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryLastCommittedPublicRand", reflect.TypeOf((*MockConsumerController)(nil).QueryLastCommittedPublicRand), fpPk)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryLastPublicRandCommit", reflect.TypeOf((*MockConsumerController)(nil).QueryLastPublicRandCommit), fpPk)
 }
 
 // QueryLatestBlockHeight mocks base method.

--- a/types/pub_rand_commit.go
+++ b/types/pub_rand_commit.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"fmt"
+
 	bbn "github.com/babylonchain/babylon/types"
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/cometbft/cometbft/crypto/merkle"
@@ -10,6 +12,15 @@ type PubRandCommit struct {
 	StartHeight uint64 `json:"start_height"`
 	NumPubRand  uint64 `json:"num_pub_rand"`
 	Commitment  []byte `json:"commitment"`
+}
+
+// Validate checks if the PubRandCommit structure is valid
+// returns an error if not.
+func (prc *PubRandCommit) Validate() error {
+	if prc.NumPubRand < 1 {
+		return fmt.Errorf("NumPubRand must be >= 1, got %d", prc.NumPubRand)
+	}
+	return nil
 }
 
 // GetPubRandCommitAndProofs commits a list of public randomness and returns

--- a/types/pub_rand_commit.go
+++ b/types/pub_rand_commit.go
@@ -7,8 +7,9 @@ import (
 )
 
 type PubRandCommit struct {
-	NumPubRand uint64 `json:"num_pub_rand"`
-	Commitment []byte `json:"commitment"`
+	StartHeight uint64 `json:"start_height"`
+	NumPubRand  uint64 `json:"num_pub_rand"`
+	Commitment  []byte `json:"commitment"`
 }
 
 // GetPubRandCommitAndProofs commits a list of public randomness and returns


### PR DESCRIPTION
## Summary

#407 

## Test Plan

```
make lint
```
wait for CI