### PR TITLE
fix: op e2e test

### DIFF
--- a/itest/babylon/babylon_e2e_test.go
+++ b/itest/babylon/babylon_e2e_test.go
@@ -28,7 +28,7 @@ func TestFinalityProviderLifeCycle(t *testing.T) {
 	fpIns := fpInsList[0]
 
 	// check the public randomness is committed
-	e2eutils.WaitForFpPubRandCommitted(t, fpIns)
+	e2eutils.WaitForFpPubRandCommitted(t, fpIns, 1)
 
 	// send a BTC delegation
 	_ = tm.InsertBTCDelegation(t, []*btcec.PublicKey{fpIns.GetBtcPk()}, e2eutils.StakingTime, e2eutils.StakingAmount)
@@ -60,7 +60,7 @@ func TestDoubleSigning(t *testing.T) {
 	fpIns := fpInsList[0]
 
 	// check the public randomness is committed
-	e2eutils.WaitForFpPubRandCommitted(t, fpIns)
+	e2eutils.WaitForFpPubRandCommitted(t, fpIns, 1)
 
 	// send a BTC delegation
 	_ = tm.InsertBTCDelegation(t, []*btcec.PublicKey{fpIns.GetBtcPk()}, e2eutils.StakingTime, e2eutils.StakingAmount)
@@ -119,7 +119,7 @@ func TestMultipleFinalityProviders(t *testing.T) {
 	// submit BTC delegations for each finality-provider
 	for _, fpi := range fpInstances {
 		// check the public randomness is committed
-		e2eutils.WaitForFpPubRandCommitted(t, fpi)
+		e2eutils.WaitForFpPubRandCommitted(t, fpi, 1)
 		// send a BTC delegation
 		_ = tm.InsertBTCDelegation(t, []*btcec.PublicKey{fpi.GetBtcPk()}, e2eutils.StakingTime, e2eutils.StakingAmount)
 	}
@@ -151,7 +151,7 @@ func TestFastSync(t *testing.T) {
 	fpIns := fpInsList[0]
 
 	// check the public randomness is committed
-	e2eutils.WaitForFpPubRandCommitted(t, fpIns)
+	e2eutils.WaitForFpPubRandCommitted(t, fpIns, 1)
 
 	// send a BTC delegation
 	_ = tm.InsertBTCDelegation(t, []*btcec.PublicKey{fpIns.GetBtcPk()}, e2eutils.StakingTime, e2eutils.StakingAmount)

--- a/itest/opstackl2/op_e2e_test.go
+++ b/itest/opstackl2/op_e2e_test.go
@@ -25,7 +25,8 @@ func TestOpSubmitFinalitySignature(t *testing.T) {
 	fpList := ctm.StartFinalityProvider(t, false, 1)
 	fpInstance := fpList[0]
 
-	e2eutils.WaitForFpPubRandCommitted(t, fpInstance)
+	// expect 2 rounds of submissions
+	e2eutils.WaitForFpPubRandCommitted(t, fpInstance, 2)
 
 	// query pub rand
 	committedPubRand, err := ctm.OpL2ConsumerCtrl.QueryLastCommittedPublicRand(fpInstance.GetBtcPk())
@@ -117,7 +118,7 @@ func TestBlockBabylonFinalized(t *testing.T) {
 	// submit BTC delegations for each finality-provider
 	for _, fp := range fpList {
 		// check the public randomness is committed
-		e2eutils.WaitForFpPubRandCommitted(t, fp)
+		e2eutils.WaitForFpPubRandCommitted(t, fp, 2)
 		// send a BTC delegation to consumer and Babylon finality providers
 		ctm.InsertBTCDelegation(t, []*btcec.PublicKey{bbnFpList[0].GetBtcPk(), fp.GetBtcPk()}, e2eutils.StakingTime, e2eutils.StakingAmount)
 	}

--- a/itest/opstackl2/op_e2e_test.go
+++ b/itest/opstackl2/op_e2e_test.go
@@ -4,7 +4,6 @@
 package e2etest_op
 
 import (
-	"encoding/hex"
 	"math/rand"
 	"testing"
 
@@ -115,7 +114,6 @@ func TestBlockBabylonFinalized(t *testing.T) {
 	n := 1
 	fpList := ctm.StartFinalityProvider(t, false, n)
 
-	var mockHash []byte
 	// submit BTC delegations for each finality-provider
 	for _, fp := range fpList {
 		// check the public randomness is committed
@@ -139,12 +137,16 @@ func TestBlockBabylonFinalized(t *testing.T) {
 	// check the BTC delegations are active
 	_ = ctm.WaitForNActiveDels(t, 1)
 
-	var lastCommittedStartHeight uint64
+	// test block data
+	testBlock := &types.BlockInfo{
+		Height: uint64(0),
+		Hash:   []byte("30b3a087ec3b9800f2ae7aeeb4c3fd1b4fe50578c14381568874949b08858118"),
+	}
 	for _, fp := range fpList {
 		// query pub rand
 		committedPubRand, err := ctm.OpL2ConsumerCtrl.QueryLastCommittedPublicRand(fp.GetBtcPk())
 		require.NoError(t, err)
-		lastCommittedStartHeight = committedPubRand.StartHeight
+		lastCommittedStartHeight := committedPubRand.StartHeight
 		t.Logf("Last committed pubrandList startHeight %d", lastCommittedStartHeight)
 
 		pubRandList, err := fp.GetPubRandList(lastCommittedStartHeight, ctm.FpConfig.NumPubRand)
@@ -152,15 +154,11 @@ func TestBlockBabylonFinalized(t *testing.T) {
 		// generate commitment and proof for each public randomness
 		_, proofList := types.GetPubRandCommitAndProofs(pubRandList)
 
-		// mock block hash
-		r := rand.New(rand.NewSource(1))
-		mockHash := datagen.GenRandomByteArray(r, 32)
-		block := &types.BlockInfo{
-			Height: lastCommittedStartHeight,
-			Hash:   mockHash,
-		}
+		// set the test block height
+		testBlock.Height = lastCommittedStartHeight
+
 		// fp sign
-		fpSig, err := fp.SignFinalitySig(block)
+		fpSig, err := fp.SignFinalitySig(testBlock)
 		require.NoError(t, err)
 
 		// pub rand proof
@@ -168,20 +166,21 @@ func TestBlockBabylonFinalized(t *testing.T) {
 		require.NoError(t, err)
 
 		// submit finality signature to smart contract
-		submitRes, err := ctm.OpL2ConsumerCtrl.SubmitFinalitySig(
+		_, err = ctm.OpL2ConsumerCtrl.SubmitFinalitySig(
 			fp.GetBtcPk(),
-			block,
+			testBlock,
 			pubRandList[0],
 			proof,
 			fpSig.ToModNScalar(),
 		)
 		require.NoError(t, err)
-		t.Logf("Submit finality signature to op finality contract %s", submitRes.TxHash)
+		t.Logf("Submit finality signature to op finality contract %+v\n", testBlock)
 	}
 
 	queryParams := &sdk.L2Block{
-		BlockHeight: lastCommittedStartHeight,
-		BlockHash:   hex.EncodeToString(mockHash),
+		BlockHeight: testBlock.Height,
+		// use the same UTF-8 encoding in CW contract
+		BlockHash: string(testBlock.Hash),
 		/*
 			this is BTC height 10's timestamp: https://mempool.space/block/10
 

--- a/itest/opstackl2/op_test_manager.go
+++ b/itest/opstackl2/op_test_manager.go
@@ -77,9 +77,9 @@ func StartOpL2ConsumerManager(t *testing.T) *OpL2ConsumerTestManager {
 	require.NoError(t, err)
 	fpHomeDir := filepath.Join(testDir, "fp-home")
 	cfg := e2eutils.DefaultFpConfig(bh.GetNodeDataDir(), fpHomeDir)
-	cfg.StatusUpdateInterval = 500 * time.Millisecond
-	cfg.RandomnessCommitInterval = 500 * time.Millisecond
-	cfg.FastSyncInterval = 1 * time.Second
+	cfg.StatusUpdateInterval = 2 * time.Second
+	cfg.RandomnessCommitInterval = 2 * time.Second
+	cfg.FastSyncInterval = 2 * time.Second
 	cfg.NumPubRand = 64
 	bc, err := bbncc.NewBabylonController(cfg.BabylonConfig, &cfg.BTCNetParams, logger)
 	require.NoError(t, err)

--- a/itest/opstackl2/op_test_manager.go
+++ b/itest/opstackl2/op_test_manager.go
@@ -38,6 +38,10 @@ import (
 const (
 	opFinalityGadgetContractPath = "../bytecode/op_finality_gadget_c6ccca8.wasm"
 	opConsumerId                 = "op-stack-l2-12345"
+	// it has to be a valid EVM RPC which doesn't timeout
+	opStackL2RPCAddress = "https://rpc.ankr.com/eth"
+	// it has to be a valid addr that can be passed into `sdktypes.AccAddressFromBech32()`
+	opFinalityGadgetAddress = "bbn1ghd753shjuwexxywmgs4xz7x2q732vcnkm6h2pyv9s6ah3hylvrqxxvh0f"
 )
 
 type BaseTestManager = base_test_manager.BaseTestManager
@@ -163,10 +167,8 @@ func mockOpL2ConsumerCtrlConfig(nodeDataDir string) *fpcfg.OPStackL2Config {
 
 	// fill up the config from dc config
 	return &fpcfg.OPStackL2Config{
-		// it has to be a valid EVM RPC which doesn't timeout
-		OPStackL2RPCAddress: "https://rpc.ankr.com/eth",
-		// it has to be a valid addr that can be passed into `sdktypes.AccAddressFromBech32()`
-		OPFinalityGadgetAddress: "bbn1ghd753shjuwexxywmgs4xz7x2q732vcnkm6h2pyv9s6ah3hylvrqxxvh0f",
+		OPStackL2RPCAddress:     opStackL2RPCAddress,
+		OPFinalityGadgetAddress: opFinalityGadgetAddress,
 		Key:                     dc.Key,
 		ChainID:                 dc.ChainID,
 		RPCAddr:                 dc.RPCAddr,

--- a/itest/utils.go
+++ b/itest/utils.go
@@ -84,13 +84,17 @@ func GenerateCovenantCommittee(numCovenants int, t *testing.T) ([]*btcec.Private
 	return covenantPrivKeys, covenantPubKeys
 }
 
-func WaitForFpPubRandCommitted(t *testing.T, fpIns *service.FinalityProviderInstance) {
+func WaitForFpPubRandCommitted(t *testing.T, fpIns *service.FinalityProviderInstance, n int) {
+	count := 0
 	require.Eventually(t, func() bool {
 		lastCommittedHeight, err := fpIns.GetLastCommittedHeight()
 		if err != nil {
 			return false
 		}
-		return lastCommittedHeight > 0
+		if lastCommittedHeight > 0 {
+			count++
+		}
+		return count >= n
 	}, EventuallyWaitTimeOut, EventuallyPollTime)
 
 	t.Logf("Public randomness is successfully committed")

--- a/itest/utils.go
+++ b/itest/utils.go
@@ -84,6 +84,7 @@ func GenerateCovenantCommittee(numCovenants int, t *testing.T) ([]*btcec.Private
 	return covenantPrivKeys, covenantPubKeys
 }
 
+// n means expect n rounds of submissions
 func WaitForFpPubRandCommitted(t *testing.T, fpIns *service.FinalityProviderInstance, n int) {
 	count := 0
 	require.Eventually(t, func() bool {


### PR DESCRIPTION
This PR fixes the op e2e test issue which was caused by the block hash with the wrong format.

## Test Plan

```
make test
make test-e2e
```