### PR TITLE
test: create anvil devnet for tests

### DIFF
--- a/itest/ethereum_node_handler.go
+++ b/itest/ethereum_node_handler.go
@@ -1,0 +1,101 @@
+package e2e_utils
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/stretchr/testify/require"
+)
+
+type EthereumNodeHandler struct {
+	t           *testing.T
+	client 			*rpc.Client
+}
+
+func NewEthereumNodeHandler(t *testing.T) (*EthereumNodeHandler, error) {
+	// Log current working directory
+	wd, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+	t.Logf("Current working directory: %s", wd)
+
+	// Start Anvil
+	projectRoot, err := findProjectRoot()
+	if err != nil {
+		return nil, err
+	}
+	startScriptPath := filepath.Join(projectRoot, "scripts/start_anvil_devnet.sh")
+	if err != nil {
+		return nil, err
+	}
+	if err := os.Chmod(startScriptPath, 0755); err != nil {
+		return nil, err
+	}
+
+	var stdout, stderr bytes.Buffer
+	startCmd := exec.Command("/bin/sh", startScriptPath)
+	startCmd.Stdout = &stdout
+	startCmd.Stderr = &stderr
+	if err := startCmd.Start(); err != nil {
+		return nil, err
+	}
+
+	// Wait for the command to complete
+	startCmd.Wait()
+
+	// Log output and errors
+	if stdout.Len() > 0 {
+		t.Logf("Anvil stdout: %s", stdout.String())
+	}
+	if stderr.Len() > 0 {
+		t.Logf("Anvil stderr: %s", stderr.String())
+	}
+
+	// Connect to local RPC node
+	client, err := rpc.DialHTTP("http://localhost:8545")
+	if err != nil {
+		return nil, err
+	}
+	
+	return &EthereumNodeHandler{
+		t:           t,
+		client:      client,
+	}, nil
+}
+
+func (eh *EthereumNodeHandler) Close() {
+	if eh.client != nil {
+		eh.client.Close()
+	}
+
+	// Stop Anvil
+	projectRoot, err := findProjectRoot()
+	require.NoError(eh.t, err)
+	stopScriptPath := filepath.Join(projectRoot, "scripts/stop_anvil_devnet.sh")
+	os.Chmod(stopScriptPath, 0755)
+	stopCmd := exec.Command("/bin/sh", stopScriptPath)
+	stopCmd.Run()
+}
+
+// Helper function to find root directory of project
+func findProjectRoot() (string, error) {
+	_, b, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(b)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+		if parentDir := filepath.Dir(dir); parentDir == dir {
+			break
+		} else {
+			dir = parentDir
+		}
+	}
+	return "", os.ErrNotExist
+}

--- a/itest/opstackl2/op_e2e_test.go
+++ b/itest/opstackl2/op_e2e_test.go
@@ -109,6 +109,12 @@ func TestBlockBabylonFinalized(t *testing.T) {
 	ctm := StartOpL2ConsumerManager(t)
 	defer ctm.Stop(t)
 
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Test panicked: %v", r)
+		}
+	}()
+
 	// A BTC delegation has to stake to at least one Babylon finality provider
 	// https://github.com/babylonchain/babylon-private/blob/base/consumer-chain-support/x/btcstaking/keeper/msg_server.go#L169-L213
 	// So we have to start Babylon chain FP

--- a/scripts/start_anvil_devnet.sh
+++ b/scripts/start_anvil_devnet.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Detect the project root directory
+PROJECT_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+
+# Check if anvil binary is available
+if ! command -v anvil &> /dev/null; then
+    echo "Anvil not found. Installing Anvil..."
+    curl -L https://foundry.paradigm.xyz | bash
+    foundryup
+    export PATH=$PATH:$HOME/.foundry/bin
+    echo "Anvil installed and added to PATH."
+fi
+
+# Check if the anvil process is running
+if pgrep -x "anvil" > /dev/null; then
+  echo "Anvil is already running, stopping it..."
+  pkill -x "anvil"
+fi
+
+# Start the anvil process with nohup
+echo "Starting anvil process..."
+nohup anvil -b 3 --optimism > "$PROJECT_ROOT/anvil.log" 2>&1 &
+echo "Anvil process started, outputting to anvil.log"

--- a/scripts/stop_anvil_devnet.sh
+++ b/scripts/stop_anvil_devnet.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Check if anvil binary is available
+if ! command -v anvil &> /dev/null; then
+    exit 1
+fi
+
+# Check if the anvil process is running
+if pgrep -x "anvil" > /dev/null; then
+  echo "Stopping Anvil..."
+  pkill -x "anvil"
+fi


### PR DESCRIPTION
## Summary

Current OP e2e tests use an external RPC provider which is subject to rate limiting.

This PR replaces the external RPC with a local [Anvil](https://book.getfoundry.sh/anvil/) devnet instance run inside the test manager. It is run in memory and torn down at test completion, with logs stored at `anvil.log` for debugging. 

## Test Plan

```
make install
make test e2e-op
```

Note: this PR is superseded by https://github.com/babylonchain/finality-provider/pull/447