### PR TITLE
fix: non-op logger in itests

### DIFF
--- a/finality-provider/config/config.go
+++ b/finality-provider/config/config.go
@@ -10,6 +10,7 @@ import (
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/jessevdk/go-flags"
+	"go.uber.org/zap/zapcore"
 
 	eotscfg "github.com/babylonchain/finality-provider/eotsmanager/config"
 	"github.com/babylonchain/finality-provider/metrics"
@@ -18,7 +19,7 @@ import (
 
 const (
 	defaultChainName               = "babylon"
-	defaultLogLevel                = "info"
+	defaultLogLevel                = zapcore.InfoLevel
 	defaultLogDirname              = "logs"
 	defaultLogFilename             = "fpd.log"
 	defaultFinalityProviderKeyName = "finality-provider"
@@ -94,7 +95,7 @@ func DefaultConfigWithHome(homePath string) Config {
 	pollerCfg := DefaultChainPollerConfig()
 	cfg := Config{
 		ChainName:                defaultChainName,
-		LogLevel:                 defaultLogLevel,
+		LogLevel:                 defaultLogLevel.String(),
 		DatabaseConfig:           DefaultDBConfigWithHomePath(homePath),
 		BabylonConfig:            &bbnCfg,
 		PollerConfig:             &pollerCfg,

--- a/finality-provider/config/opstackl2.go
+++ b/finality-provider/config/opstackl2.go
@@ -13,15 +13,15 @@ type OPStackL2Config struct {
 	OPStackL2RPCAddress     string `long:"opstackl2-rpc-address" description:"the rpc address of the op-stack-l2 node to connect to"`
 	OPFinalityGadgetAddress string `long:"op-finality-gadget" description:"the contract address of the op-finality-gadget"`
 	// Below configurations are needed for the Babylon client
-	Key            string        `long:"key" description:"name of the key to sign transactions with"`
-	ChainID        string        `long:"chain-id" description:"chain id of the chain to connect to"`
-	RPCAddr        string        `long:"rpc-address" description:"address of the rpc server to connect to"`
-	GRPCAddr       string        `long:"grpc-address" description:"address of the grpc server to connect to"`
-	AccountPrefix  string        `long:"acc-prefix" description:"account prefix to use for addresses"`
+	Key            string        `long:"key" description:"name of the babylon key to sign transactions with"`
+	ChainID        string        `long:"chain-id" description:"chain id of the babylon chain to connect to"`
+	RPCAddr        string        `long:"rpc-address" description:"address of the babylon rpc server to connect to"`
+	GRPCAddr       string        `long:"grpc-address" description:"address of the babylon grpc server to connect to"`
+	AccountPrefix  string        `long:"acc-prefix" description:"babylon account prefix to use for addresses"`
 	KeyringBackend string        `long:"keyring-type" description:"type of keyring to use"`
-	GasAdjustment  float64       `long:"gas-adjustment" description:"adjustment factor when using gas estimation"`
-	GasPrices      string        `long:"gas-prices" description:"comma separated minimum gas prices to accept for transactions"`
-	KeyDirectory   string        `long:"key-dir" description:"directory to store keys in"`
+	GasAdjustment  float64       `long:"gas-adjustment" description:"adjustment factor when using babylon gas estimation"`
+	GasPrices      string        `long:"gas-prices" description:"comma separated minimum babylon gas prices to accept for transactions"`
+	KeyDirectory   string        `long:"key-dir" description:"directory to store babylon keys in"`
 	Debug          bool          `long:"debug" description:"flag to print debug output"`
 	Timeout        time.Duration `long:"timeout" description:"client timeout when doing queries"`
 	BlockTimeout   time.Duration `long:"block-timeout" description:"block timeout when waiting for block events"`

--- a/finality-provider/service/fp_instance.go
+++ b/finality-provider/service/fp_instance.go
@@ -725,7 +725,13 @@ func (fp *FinalityProviderInstance) SubmitFinalitySignature(b *types.BlockInfo) 
 	// get inclusion proof
 	proofBytes, err := fp.pubRandState.GetPubRandProof(pubRand)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get inclusion proof of public randomness: %v", err)
+		return nil, fmt.Errorf(
+			"failed to get inclusion proof of public randomness %s for FP %s for block %d: %w",
+			pubRand.String(),
+			fp.btcPk.MarshalHex(),
+			b.Height,
+			err,
+		)
 	}
 
 	// send finality signature to the consumer chain

--- a/itest/babylon_node_handler.go
+++ b/itest/babylon_node_handler.go
@@ -145,6 +145,7 @@ func NewBabylonNodeHandler(t *testing.T, covenantQuorum int, covenantPks []*type
 	require.NoError(t, err)
 
 	f, err := os.Create(filepath.Join(testDir, "babylon.log"))
+	t.Logf("babylon log file: %s", f.Name())
 	require.NoError(t, err)
 
 	startCmd := exec.Command(

--- a/itest/opstackl2/op_test_manager.go
+++ b/itest/opstackl2/op_test_manager.go
@@ -64,7 +64,10 @@ func StartOpL2ConsumerManager(t *testing.T) *OpL2ConsumerTestManager {
 	testDir, err := e2eutils.BaseDir("fpe2etest")
 	require.NoError(t, err)
 
-	logger := zap.NewNop()
+	loggerConfig := zap.NewDevelopmentConfig()
+	loggerConfig.Level = zap.NewAtomicLevelAt(zap.ErrorLevel)
+	logger, err := loggerConfig.Build()
+	require.NoError(t, err)
 
 	// 1. generate covenant committee
 	covenantQuorum := 2
@@ -76,6 +79,7 @@ func StartOpL2ConsumerManager(t *testing.T) *OpL2ConsumerTestManager {
 	err = bh.Start()
 	require.NoError(t, err)
 	fpHomeDir := filepath.Join(testDir, "fp-home")
+	t.Logf("Fp home dir: %s", fpHomeDir)
 	cfg := e2eutils.DefaultFpConfig(bh.GetNodeDataDir(), fpHomeDir)
 	cfg.StatusUpdateInterval = 2 * time.Second
 	cfg.RandomnessCommitInterval = 2 * time.Second
@@ -423,6 +427,7 @@ func getLatestCodeId(opcc *opstackl2.OPStackL2ConsumerController) (uint64, error
 }
 
 func (ctm *OpL2ConsumerTestManager) Stop(t *testing.T) {
+	t.Log("Stopping test manager")
 	var err error
 	// FpApp has to stop first or you will get "rpc error: desc = account xxx not found: key not found" error
 	// b/c when Babylon daemon is stopped, FP won't be able to find the keyring backend

--- a/itest/opstackl2/op_test_manager.go
+++ b/itest/opstackl2/op_test_manager.go
@@ -115,12 +115,10 @@ func StartOpL2ConsumerManager(t *testing.T) *OpL2ConsumerTestManager {
 	require.NoError(t, err)
 	err = instantiateWasmContract(opcc, opFinalityGadgetContractWasmId, opFinalityGadgetInitMsgBytes)
 	require.NoError(t, err)
-
 	// get op contract address
 	resp, err := opcc.CwClient.ListContractsByCode(opFinalityGadgetContractWasmId, &sdkquerytypes.PageRequest{})
 	require.NoError(t, err)
 	require.Len(t, resp.Contracts, 1)
-
 	// update the contract address in config to replace a placeholder address
 	// previously used to bypass the validation
 	opcc.Cfg.OPFinalityGadgetAddress = resp.Contracts[0]

--- a/itest/utils.go
+++ b/itest/utils.go
@@ -67,7 +67,10 @@ func RunCommand(name string, args ...string) ([]byte, error) {
 	return output, nil
 }
 
-func GenerateCovenantCommittee(numCovenants int, t *testing.T) ([]*btcec.PrivateKey, []*bbntypes.BIP340PubKey) {
+func GenerateCovenantCommittee(
+	numCovenants int,
+	t *testing.T,
+) ([]*btcec.PrivateKey, []*bbntypes.BIP340PubKey) {
 	var (
 		covenantPrivKeys []*btcec.PrivateKey
 		covenantPubKeys  []*bbntypes.BIP340PubKey
@@ -94,12 +97,15 @@ func WaitForFpPubRandCommitted(t *testing.T, fpIns *service.FinalityProviderInst
 			return false
 		}
 		if lastCommittedHeight > 0 {
+			t.Logf(
+				"Public randomness for fp %s is successfully committed at height %d",
+				fpIns.GetBtcPkHex(),
+				lastCommittedHeight,
+			)
 			count++
 		}
 		return count >= n
 	}, EventuallyWaitTimeOut, EventuallyPollTime)
-
-	t.Logf("Public randomness is successfully committed")
 }
 
 func DefaultFpConfig(keyringDir, homeDir string) *config.Config {
@@ -123,7 +129,9 @@ func DefaultFpConfig(keyringDir, homeDir string) *config.Config {
 // ParseRespBTCDelToBTCDel parses an BTC delegation response to BTC Delegation
 // adapted from
 // https://github.com/babylonchain/babylon/blob/1a3c50da64885452c8d669fcea2a2fad78c8a028/test/e2e/btc_staking_e2e_test.go#L548
-func ParseRespBTCDelToBTCDel(resp *bstypes.BTCDelegationResponse) (btcDel *bstypes.BTCDelegation, err error) {
+func ParseRespBTCDelToBTCDel(
+	resp *bstypes.BTCDelegationResponse,
+) (btcDel *bstypes.BTCDelegation, err error) {
 	stakingTx, err := hex.DecodeString(resp.StakingTxHex)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

https://github.com/babylonchain/finality-provider/issues/449

also per @maurolacy's suggestion https://github.com/babylonchain/finality-provider/pull/447#discussion_r1660667470, I moved the logger changes to this PR

also added some other log related improvements in this PR

## Test Plan

```
make lint
```

wait for CI