### PR TITLE
fix: add missing Config.Validate()

### DIFF
--- a/clientcontroller/opstackl2/consumer.go
+++ b/clientcontroller/opstackl2/consumer.go
@@ -46,6 +46,9 @@ func NewOPStackL2ConsumerController(
 	if opl2Cfg == nil {
 		return nil, fmt.Errorf("nil config for OP consumer controller")
 	}
+	if err := opl2Cfg.Validate(); err != nil {
+		return nil, err
+	}
 	cwConfig := opl2Cfg.ToCosmwasmConfig()
 	if err := cwConfig.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid config for OP consumer controller: %w", err)


### PR DESCRIPTION
## Summary

just realized that we have define this method in `finality-provider/config/opstackl2.go` but never used it

not sure why but let's add it

## Test Plan

```
make lint
```
wait for CI