### PR TITLE
fix: start height of initial public randomness commit

### DIFF
--- a/finality-provider/service/fastsync_test.go
+++ b/finality-provider/service/fastsync_test.go
@@ -32,7 +32,6 @@ func FuzzFastSync_SufficientRandomness(f *testing.F) {
 
 		// commit pub rand
 		mockConsumerController.EXPECT().QueryLastPublicRandCommit(gomock.Any()).Return(nil, nil).Times(1)
-		mockConsumerController.EXPECT().CommitPubRandList(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
 		_, err := fpIns.CommitPubRand(randomStartingHeight)
 		require.NoError(t, err)
 
@@ -85,7 +84,6 @@ func FuzzFastSync_NoRandomness(f *testing.F) {
 
 		// commit pub rand
 		mockConsumerController.EXPECT().QueryLastPublicRandCommit(gomock.Any()).Return(nil, nil).Times(1)
-		mockConsumerController.EXPECT().CommitPubRandList(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
 		_, err := fpIns.CommitPubRand(randomStartingHeight)
 		require.NoError(t, err)
 

--- a/finality-provider/service/fp_instance.go
+++ b/finality-provider/service/fp_instance.go
@@ -119,7 +119,7 @@ func (fp *FinalityProviderInstance) Start() error {
 
 	poller := NewChainPoller(fp.logger, fp.cfg.PollerConfig, fp.cc, fp.consumerCon, fp.metrics)
 
-	if err := poller.Start(startHeight + 1); err != nil {
+	if err := poller.Start(startHeight); err != nil {
 		return fmt.Errorf("failed to start the poller: %w", err)
 	}
 
@@ -132,7 +132,7 @@ func (fp *FinalityProviderInstance) Start() error {
 	fp.wg.Add(1)
 	go fp.finalitySigSubmissionLoop()
 	fp.wg.Add(1)
-	go fp.randomnessCommitmentLoop()
+	go fp.randomnessCommitmentLoop(startHeight)
 	fp.wg.Add(1)
 	go fp.checkLaggingLoop()
 
@@ -283,21 +283,50 @@ func (fp *FinalityProviderInstance) finalitySigSubmissionLoop() {
 	}
 }
 
-func (fp *FinalityProviderInstance) randomnessCommitmentLoop() {
+func (fp *FinalityProviderInstance) randomnessCommitmentLoop(startHeight uint64) {
 	defer fp.wg.Done()
 
 	commitRandTicker := time.NewTicker(fp.cfg.RandomnessCommitInterval)
 	defer commitRandTicker.Stop()
 
+	lastCommittedHeight, err := fp.GetLastCommittedHeight()
+	if err != nil {
+		fp.logger.Fatal("Error getting last committed height while starting the randomness commitment loop", zap.Error(err))
+		return
+	}
+
+	// if there is no committed randomness, we need to commit the first randomness
+	if lastCommittedHeight == uint64(0) {
+		txRes, err := fp.retryCommitPubRandUntilMaxRetry(startHeight)
+		if err != nil {
+			fp.metrics.IncrementFpTotalFailedRandomness(fp.GetBtcPkHex())
+			fp.reportCriticalErr(err)
+			return
+		}
+		if txRes == nil {
+			fp.logger.Fatal(
+				"Error submitting the first randomness",
+				zap.String("consumer_id", string(fp.GetChainID())),
+				zap.String("pk", fp.GetBtcPkHex()),
+			)
+			return
+		}
+		fp.logger.Info(
+			"successfully committed public randomness to the consumer chain",
+			zap.String("consumer_id", string(fp.GetChainID())),
+			zap.String("pk", fp.GetBtcPkHex()),
+		)
+	}
+
 	for {
 		select {
 		case <-commitRandTicker.C:
-			tipBlock, err := fp.getLatestBlockHeightWithRetry()
+			tipBlockHeight, err := fp.getLatestBlockHeightWithRetry()
 			if err != nil {
 				fp.reportCriticalErr(err)
 				continue
 			}
-			txRes, err := fp.retryCommitPubRandUntilBlockFinalized(tipBlock)
+			txRes, err := fp.retryCommitPubRandUntilBlockFinalized(tipBlockHeight)
 			if err != nil {
 				fp.metrics.IncrementFpTotalFailedRandomness(fp.GetBtcPkHex())
 				fp.reportCriticalErr(err)
@@ -644,10 +673,54 @@ func (fp *FinalityProviderInstance) retryCommitPubRandUntilBlockFinalized(target
 	}
 }
 
+func (fp *FinalityProviderInstance) retryCommitPubRandUntilMaxRetry(targetBlockHeight uint64) (*types.TxResponse, error) {
+	var failedCycles uint32
+
+	// we break the for loop if the public rand is successfully committed
+	// error will be returned if maximum retries have been reached
+	for {
+		// error will be returned if max retries have been reached
+		// TODO: CommitPubRand also includes saving all inclusion proofs of public randomness
+		// this part should not be retried here. We need to separate the function into
+		// 1) determining the starting height to commit, 2) generating pub rand and inclusion
+		//  proofs, and 3) committing public randomness.
+		// TODO: make 3) a part of `select` statement. The function terminates upon either the block
+		// is finalised or the pub rand is committed successfully
+		res, err := fp.CommitPubRand(targetBlockHeight)
+		if err != nil {
+			if fpcc.IsUnrecoverable(err) {
+				return nil, err
+			}
+			fp.logger.Debug(
+				"failed to commit public randomness to the consumer chain",
+				zap.String("pk", fp.GetBtcPkHex()),
+				zap.Uint32("current_failures", failedCycles),
+				zap.Uint64("target_block_height", targetBlockHeight),
+				zap.Error(err),
+			)
+
+			failedCycles += 1
+			if failedCycles > uint32(fp.cfg.MaxSubmissionRetries) {
+				return nil, fmt.Errorf("reached max failed cycles with err: %w", err)
+			}
+		} else {
+			// the public randomness has been successfully submitted
+			return res, nil
+		}
+		select {
+		case <-time.After(fp.cfg.SubmissionRetryInterval):
+			continue
+		case <-fp.quit:
+			fp.logger.Debug("the finality-provider instance is closing", zap.String("pk", fp.GetBtcPkHex()))
+			return nil, nil
+		}
+	}
+}
+
 // CommitPubRand generates a list of Schnorr rand pairs,
 // commits the public randomness for the managed finality providers,
 // and save the randomness pair to DB
-func (fp *FinalityProviderInstance) CommitPubRand(tipHeight uint64) (*types.TxResponse, error) {
+func (fp *FinalityProviderInstance) CommitPubRand(targetBlockHeight uint64) (*types.TxResponse, error) {
 	lastCommittedHeight, err := fp.GetLastCommittedHeight()
 	if err != nil {
 		return nil, err
@@ -656,8 +729,8 @@ func (fp *FinalityProviderInstance) CommitPubRand(tipHeight uint64) (*types.TxRe
 	var startHeight uint64
 	if lastCommittedHeight == uint64(0) {
 		// the finality-provider has never submitted public rand before
-		startHeight = tipHeight + 1
-	} else if lastCommittedHeight < fp.cfg.MinRandHeightGap+tipHeight {
+		startHeight = targetBlockHeight
+	} else if lastCommittedHeight < fp.cfg.MinRandHeightGap+targetBlockHeight {
 		// (should not use subtraction because they are in the type of uint64)
 		// we are running out of the randomness
 		startHeight = lastCommittedHeight + 1
@@ -665,7 +738,7 @@ func (fp *FinalityProviderInstance) CommitPubRand(tipHeight uint64) (*types.TxRe
 		fp.logger.Debug(
 			"the finality-provider has sufficient public randomness, skip committing more",
 			zap.String("pk", fp.GetBtcPkHex()),
-			zap.Uint64("block_height", tipHeight),
+			zap.Uint64("block_height", targetBlockHeight),
 			zap.Uint64("last_committed_height", lastCommittedHeight),
 		)
 		return nil, nil
@@ -883,17 +956,14 @@ func (fp *FinalityProviderInstance) getPollerStartingHeight() (uint64, error) {
 	if err != nil {
 		return 0, err
 	}
-	if latestFinalisedBlock != nil {
-		if latestFinalisedBlock.Height > initialBlockToGet {
-			initialBlockToGet = latestFinalisedBlock.Height
-		}
+
+	// find max(initialBlockToGet, latestFinalisedBlock.Height)
+	maxHeight := initialBlockToGet
+	if latestFinalisedBlock != nil && latestFinalisedBlock.Height > initialBlockToGet {
+		maxHeight = latestFinalisedBlock.Height
 	}
 
-	// ensure that initialBlockToGet is at least 1
-	if initialBlockToGet == 0 {
-		initialBlockToGet = 1
-	}
-	return initialBlockToGet, nil
+	return maxHeight + 1, nil
 }
 
 func (fp *FinalityProviderInstance) GetLastCommittedHeight() (uint64, error) {

--- a/finality-provider/service/fp_instance.go
+++ b/finality-provider/service/fp_instance.go
@@ -943,8 +943,8 @@ func (fp *FinalityProviderInstance) getPollerStartingHeight() (uint64, error) {
 	}
 
 	// Set initial block to the maximum of
-	//    - last processed height
-	//    - the latest Babylon finalised height
+	//    - last processed height + 1
+	//    - the latest Babylon finalised height + 1
 	// The above is to ensure that:
 	//
 	//	(1) Any finality-provider that is eligible to vote for a block,

--- a/itest/opstackl2/op_e2e_test.go
+++ b/itest/opstackl2/op_e2e_test.go
@@ -112,7 +112,7 @@ func TestBlockBabylonFinalized(t *testing.T) {
 	// A BTC delegation has to stake to at least one Babylon finality provider
 	// https://github.com/babylonchain/babylon-private/blob/base/consumer-chain-support/x/btcstaking/keeper/msg_server.go#L169-L213
 	// So we have to start Babylon chain FP
-	bbnFpList := ctm.StartFinalityProvider(t, true, 1)
+	bbnFpPk := ctm.RegisterBBNFinalityProvider(t)
 
 	// start consumer chain FP
 	n := 2
@@ -124,8 +124,8 @@ func TestBlockBabylonFinalized(t *testing.T) {
 
 	// send a BTC delegation to consumer and Babylon finality providers
 	// for the first FP, we give it more power b/c it will be used later
-	ctm.InsertBTCDelegation(t, []*btcec.PublicKey{bbnFpList[0].GetBtcPk(), fpList[0].GetBtcPk()}, e2eutils.StakingTime, 3*e2eutils.StakingAmount)
-	ctm.InsertBTCDelegation(t, []*btcec.PublicKey{bbnFpList[0].GetBtcPk(), fpList[1].GetBtcPk()}, e2eutils.StakingTime, e2eutils.StakingAmount)
+	ctm.InsertBTCDelegation(t, []*btcec.PublicKey{bbnFpPk, fpList[0].GetBtcPk()}, e2eutils.StakingTime, 3*e2eutils.StakingAmount)
+	ctm.InsertBTCDelegation(t, []*btcec.PublicKey{bbnFpPk, fpList[1].GetBtcPk()}, e2eutils.StakingTime, e2eutils.StakingAmount)
 
 	// check the BTC delegations are pending
 	delsResp := ctm.WaitForNPendingDels(t, n)

--- a/itest/opstackl2/op_test_manager.go
+++ b/itest/opstackl2/op_test_manager.go
@@ -30,6 +30,7 @@ import (
 	e2eutils "github.com/babylonchain/finality-provider/itest"
 	base_test_manager "github.com/babylonchain/finality-provider/itest/test-manager"
 	"github.com/babylonchain/finality-provider/types"
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	sdkquery "github.com/cosmos/cosmos-sdk/types/query"
 	sdkquerytypes "github.com/cosmos/cosmos-sdk/types/query"
@@ -283,6 +284,26 @@ func (ctm *OpL2ConsumerTestManager) fpSubmitFinalitySignature(t *testing.T, fp *
 	)
 	require.NoError(t, err)
 	t.Logf("Submit finality signature to op finality contract %+v\n", testBlock)
+}
+
+func (ctm *OpL2ConsumerTestManager) RegisterBBNFinalityProvider(t *testing.T) *btcec.PublicKey {
+	app := ctm.FpApp
+	chainId := e2eutils.ChainID
+	fpName := chainId + "-" + e2eutils.FpNamePrefix
+	moniker := chainId + "-" + e2eutils.MonikerPrefix
+	commission := sdkmath.LegacyZeroDec()
+	desc := e2eutils.NewDescription(moniker)
+	cfg := app.GetConfig()
+	_, err := service.CreateChainKey(cfg.BabylonConfig.KeyDirectory, cfg.BabylonConfig.ChainID, fpName, keyring.BackendTest, e2eutils.Passphrase, e2eutils.HdPath, "")
+	require.NoError(t, err)
+	res, err := app.CreateFinalityProvider(fpName, chainId, e2eutils.Passphrase, e2eutils.HdPath, desc, &commission)
+	require.NoError(t, err)
+	fpPk, err := bbntypes.NewBIP340PubKeyFromHex(res.FpInfo.BtcPkHex)
+	require.NoError(t, err)
+	_, err = app.RegisterFinalityProvider(fpPk.MarshalHex())
+	require.NoError(t, err)
+	t.Logf("Registered Finality Provider %s for %s", fpPk.MarshalHex(), chainId)
+	return fpPk.MustToBTCPK()
 }
 
 func (ctm *OpL2ConsumerTestManager) StartFinalityProvider(t *testing.T, isBabylonFp bool, n int) []*service.FinalityProviderInstance {


### PR DESCRIPTION
## Summary

see discussion here https://github.com/babylonchain/finality-provider/pull/447#discussion_r1660074723

let's first list the facts and requirements:

facts:
- first PR submissoin is based on tip height (e.g. height 27)
- chain poller starts from the lowest non-finalized height that the fp has not processed. (e.g. height 2)
- finalitySigSubmissionLoop receives signal from chain poller to try to submit sig from height 2 which will ofc fatal on max retry

requirements:
- we want to ensure no blocks with voting power will be missed

---

so I think the root cause is first PR submission shouldn't be determined by tipHeight. b/c it means the PR and Sig submission loops is not consistent in the start state.

my proposed fix is to add a global state firstPolledHeight that only be set once on the first poll to trigger the first PR submission





## Test Plan

comment out our changes in QueryFinalityProviderVotingPower first

```
make test-e2e-op
```

see test passed
```
$ make test-e2e-op                                                                    [15:22:07]
No processes to kill
rm -rf ~/.babylond ~/.wasmd ~/.bcd
cd tools; \
	go install -trimpath github.com/babylonchain/babylon/cmd/babylond
go test -mod=readonly -timeout=25m -v github.com/babylonchain/finality-provider/itest/opstackl2 -count=1 --tags=e2e_op --run ^TestBlockBabylonFinalized
=== RUN   TestBlockBabylonFinalized
    babylon_node_handler.go:148: babylon log file: /var/folders/9_/q4wsdnh14_s60_74cd2rbztm0000gp/T/zBabylonTest1670807382/babylon.log
    op_test_manager.go:83: Fp home dir: /var/folders/9_/q4wsdnh14_s60_74cd2rbztm0000gp/T/fpe2etest1412267153/fp-home
    setup.go:490: Generating L2 genesis l2_allocs_mode delta
    op_test_manager.go:109: Register consumer op-stack-l2-901 to Babylon
    op_test_manager.go:153: Deployed op finality contract address: bbn14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9sw76fy2
    op_test_manager.go:241: Babylon node has started
    op_test_manager.go:339: Registered Finality Provider b3996108efd9c82ca02dcc521fb39e20c2278ebf9ab58e9382b7ed962df9f64f for chain-test
    op_test_manager.go:383: The test manager is running with 1 finality-provider(s)
    op_test_manager.go:339: Registered Finality Provider 1c4b9c180ad2e9aa832e593490fa1d19e0b5fc7e81a68f12cd30efdcf12e7990 for op-stack-l2-901
    op_test_manager.go:339: Registered Finality Provider 08f021d4433b713c638fbe150f3446932ef01263de130db32ade5815b18eaba2 for op-stack-l2-901
    op_test_manager.go:383: The test manager is running with 3 finality-provider(s)
    utils.go:101: Public randomness for fp 08f021d4433b713c638fbe150f3446932ef01263de130db32ade5815b18eaba2 is successfully committed at height 65
    utils.go:101: Public randomness for fp 08f021d4433b713c638fbe150f3446932ef01263de130db32ade5815b18eaba2 is successfully committed at height 129
    utils.go:101: Public randomness for fp 1c4b9c180ad2e9aa832e593490fa1d19e0b5fc7e81a68f12cd30efdcf12e7990 is successfully committed at height 193
    utils.go:101: Public randomness for fp 1c4b9c180ad2e9aa832e593490fa1d19e0b5fc7e81a68f12cd30efdcf12e7990 is successfully committed at height 257
    base_test_manager.go:174: successfully submitted a BTC delegation
    base_test_manager.go:174: successfully submitted a BTC delegation
    base_test_manager.go:207: delegations are pending
    base_test_manager.go:227: delegations are active
    op_test_manager.go:284: Test block height 706 and 706
    op_test_manager.go:314: Submit finality signature to op finality contract &{Height:706 Hash:[163 198 161 192 245 28 28 32 201 102 21 235 1 197 250 177 144 130 99 49 168 224 213 83 0 193 77 184 49 152 223 82]}
    op_test_manager.go:314: Submit finality signature to op finality contract &{Height:706 Hash:[163 198 161 192 245 28 28 32 201 102 21 235 1 197 250 177 144 130 99 49 168 224 213 83 0 193 77 184 49 152 223 82]}
    op_e2e_test.go:190: Test case 1: block 706 is finalized
    op_test_manager.go:314: Submit finality signature to op finality contract &{Height:707 Hash:[185 213 238 184 77 103 140 11 128 213 132 155 49 115 2 116 83 205 111 62 204 148 199 207 229 103 136 55 144 13 147 230]}
    op_e2e_test.go:210: Test case 2: block 707 is not finalized
    op_test_manager.go:464: Stopping test manager
--- PASS: TestBlockBabylonFinalized (254.95s)
PASS
ok  	github.com/babylonchain/finality-provider/itest/opstackl2	256.528s
```