### PR TITLE
[RFC] chore: enable govet linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,3 +4,11 @@ run:
     - e2e_babylon
     - e2e_bcd
     - e2e_wasmd
+
+linters-settings:
+  govet:
+      # Disable all analyzers.
+      # Default: false
+      disable-all: true
+      enable:
+        - shadow


### PR DESCRIPTION
## Summary

there was a weird bug in this code that took us lots of time to debug:

<img width="1369" alt="image" src="https://github.com/babylonchain/finality-provider/assets/111917526/d94797be-9db0-40a5-a9b1-c632ee6a6ddc">

the root cause is we should use `=` instead of `:=` to avoid shadowing variables

after some research, I think we can use tools such as the 'shadow' analyzer in govet to detect this kind of problem

there are many other govet analyzers to use https://golangci-lint.run/usage/linters/#govet but I am just setting it up as an example

I think it will help improve code quality and avoid bugs. happy to hear any feedback

## Test Plan

```
make lint
```

saw 
```
itest/opstackl2/op_test_manager.go:253:3: shadow: declaration of "blocks" shadows declaration at line 250 (govet)
                blocks, err := ctm.OpL2ConsumerCtrl.QueryBlocks(startHeight, startHeight+uint64(n-1), uint64(n))
```