### PR TITLE
feat: add export of `ProofOfPossessionBTC` to `eotsd`

### DIFF
--- a/eotsmanager/cmd/eotsd/daemon/pop.go
+++ b/eotsmanager/cmd/eotsd/daemon/pop.go
@@ -1,0 +1,141 @@
+package daemon
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/cometbft/cometbft/crypto/tmhash"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	bbn "github.com/babylonchain/babylon/types"
+	btcstktypes "github.com/babylonchain/babylon/x/btcstaking/types"
+	"github.com/babylonchain/finality-provider/eotsmanager"
+	"github.com/babylonchain/finality-provider/eotsmanager/config"
+	"github.com/babylonchain/finality-provider/log"
+	"github.com/urfave/cli"
+)
+
+// PoPExport the data for exporting the PoP.
+// The PubKeyHex is the public key of the finality provider BTC key to load
+// the private key and sign the AddressSiged.
+type PoPExport struct {
+	PubKeyHex     string                           `json:"pub_key_hex"`
+	PoP           btcstktypes.ProofOfPossessionBTC `json:"pop"`
+	PoPHex        string                           `json:"pop_hex"`
+	AddressSigned string                           `json:"address_signed"`
+}
+
+var ExportPoPCommand = cli.Command{
+	Name:      "pop-export",
+	Usage:     "Exports the Proof of Possession by Signing over the finality provider address with the EOTS private key.",
+	UsageText: "pop-export [bbn-address]",
+	Description: `Parse the address received as argument, hash it with
+	sha256 and sign based on the Schnorr key associated with the key-name or btc-pk flag.
+	If the both flags are supplied, btc-pk takes priority. Use the generated signature
+	to build a Proof of Possession and exports it.`,
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  homeFlag,
+			Usage: "Path to the keyring directory",
+			Value: config.DefaultEOTSDir,
+		},
+		cli.StringFlag{
+			Name:  keyNameFlag,
+			Usage: "The name of the key to load private key for signing",
+		},
+		cli.StringFlag{
+			Name:  fpPkFlag,
+			Usage: "The public key of the finality-provider to load private key for signing",
+		},
+		cli.StringFlag{
+			Name:  passphraseFlag,
+			Usage: "The passphrase used to decrypt the keyring",
+			Value: defaultPassphrase,
+		},
+		cli.StringFlag{
+			Name:  keyringBackendFlag,
+			Usage: "The backend of the keyring",
+			Value: defaultKeyringBackend,
+		},
+	},
+	Action: ExportPoP,
+}
+
+func ExportPoP(ctx *cli.Context) error {
+	keyName := ctx.String(keyNameFlag)
+	fpPkStr := ctx.String(fpPkFlag)
+	passphrase := ctx.String(passphraseFlag)
+	keyringBackend := ctx.String(keyringBackendFlag)
+
+	args := ctx.Args()
+	bbnAddressStr := args.First()
+	if len(bbnAddressStr) == 0 {
+		return errors.New("invalid argument, please provide a valid bbn address as argument")
+	}
+
+	bbnAddr, err := sdk.AccAddressFromBech32(bbnAddressStr)
+	if err != nil {
+		return fmt.Errorf("invalid argument %s, please provide a valid bbn address as argument, err: %w", bbnAddressStr, err)
+	}
+
+	if len(fpPkStr) == 0 && len(keyName) == 0 {
+		return fmt.Errorf("at least one of the flags: %s, %s needs to be informed", keyNameFlag, fpPkFlag)
+	}
+
+	homePath, err := getHomeFlag(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to load home flag: %w", err)
+	}
+
+	cfg, err := config.LoadConfig(homePath)
+	if err != nil {
+		return fmt.Errorf("failed to load config at %s: %w", homePath, err)
+	}
+
+	logger, err := log.NewRootLoggerWithFile(config.LogFile(homePath), cfg.LogLevel)
+	if err != nil {
+		return fmt.Errorf("failed to load the logger")
+	}
+
+	dbBackend, err := cfg.DatabaseConfig.GetDbBackend()
+	if err != nil {
+		return fmt.Errorf("failed to create db backend: %w", err)
+	}
+	defer dbBackend.Close()
+
+	eotsManager, err := eotsmanager.NewLocalEOTSManager(homePath, keyringBackend, dbBackend, logger)
+	if err != nil {
+		return fmt.Errorf("failed to create EOTS manager: %w", err)
+	}
+
+	hashOfMsgToSign := tmhash.Sum(bbnAddr.Bytes())
+	btcSig, pubKey, err := singMsg(eotsManager, keyName, fpPkStr, passphrase, hashOfMsgToSign)
+	if err != nil {
+		return fmt.Errorf("failed to sign address %s: %w", bbnAddr.String(), err)
+	}
+
+	bip340Sig := bbn.NewBIP340SignatureFromBTCSig(btcSig)
+	btcSigBz, err := bip340Sig.Marshal()
+	if err != nil {
+		return fmt.Errorf("failed to marshal BTC Sig: %w", err)
+	}
+
+	pop := btcstktypes.ProofOfPossessionBTC{
+		BtcSigType: btcstktypes.BTCSigType_BIP340,
+		BtcSig:     btcSigBz,
+	}
+
+	popHex, err := pop.ToHexStr()
+	if err != nil {
+		return fmt.Errorf("failed to marshal pop to hex: %w", err)
+	}
+
+	printRespJSON(PoPExport{
+		PubKeyHex:     pubKey.MarshalHex(),
+		PoP:           pop,
+		PoPHex:        popHex,
+		AddressSigned: bbnAddr.String(),
+	})
+
+	return nil
+}

--- a/eotsmanager/cmd/eotsd/daemon/pop.go
+++ b/eotsmanager/cmd/eotsd/daemon/pop.go
@@ -15,6 +15,10 @@ import (
 	"github.com/urfave/cli"
 )
 
+func init() {
+	bbnparams.SetAddressPrefixes()
+}
+
 // PoPExport the data for exporting the PoP.
 // The PubKeyHex is the public key of the finality provider BTC key to load
 // the private key and sign the AddressSiged.
@@ -61,8 +65,6 @@ var ExportPoPCommand = cli.Command{
 }
 
 func ExportPoP(ctx *cli.Context) error {
-	bbnparams.SetAddressPrefixes()
-
 	keyName := ctx.String(keyNameFlag)
 	fpPkStr := ctx.String(fpPkFlag)
 	passphrase := ctx.String(passphraseFlag)

--- a/eotsmanager/cmd/eotsd/daemon/pop.go
+++ b/eotsmanager/cmd/eotsd/daemon/pop.go
@@ -6,6 +6,7 @@ import (
 	"github.com/cometbft/cometbft/crypto/tmhash"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
+	bbnparams "github.com/babylonchain/babylon/app/params"
 	bbn "github.com/babylonchain/babylon/types"
 	btcstktypes "github.com/babylonchain/babylon/x/btcstaking/types"
 	"github.com/babylonchain/finality-provider/eotsmanager"
@@ -60,6 +61,8 @@ var ExportPoPCommand = cli.Command{
 }
 
 func ExportPoP(ctx *cli.Context) error {
+	bbnparams.SetAddressPrefixes()
+
 	keyName := ctx.String(keyNameFlag)
 	fpPkStr := ctx.String(fpPkFlag)
 	passphrase := ctx.String(passphraseFlag)

--- a/eotsmanager/cmd/eotsd/daemon/pop.go
+++ b/eotsmanager/cmd/eotsd/daemon/pop.go
@@ -1,7 +1,6 @@
 package daemon
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/cometbft/cometbft/crypto/tmhash"
@@ -19,20 +18,19 @@ import (
 // The PubKeyHex is the public key of the finality provider BTC key to load
 // the private key and sign the AddressSiged.
 type PoPExport struct {
-	PubKeyHex     string                           `json:"pub_key_hex"`
-	PoP           btcstktypes.ProofOfPossessionBTC `json:"pop"`
-	PoPHex        string                           `json:"pop_hex"`
-	AddressSigned string                           `json:"address_signed"`
+	PubKeyHex      string `json:"pub_key_hex"`
+	PoPHex         string `json:"pop_hex"`
+	BabylonAddress string `json:"babylon_address"`
 }
 
 var ExportPoPCommand = cli.Command{
 	Name:      "pop-export",
-	Usage:     "Exports the Proof of Possession by Signing over the finality provider address with the EOTS private key.",
+	Usage:     "Exports the Proof of Possession by signing over the finality provider's Babylon address with the EOTS private key.",
 	UsageText: "pop-export [bbn-address]",
 	Description: `Parse the address received as argument, hash it with
-	sha256 and sign based on the Schnorr key associated with the key-name or btc-pk flag.
+	sha256 and sign based on the EOTS key associated with the key-name or btc-pk flag.
 	If the both flags are supplied, btc-pk takes priority. Use the generated signature
-	to build a Proof of Possession and exports it.`,
+	to build a Proof of Possession and export it.`,
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  homeFlag,
@@ -69,10 +67,6 @@ func ExportPoP(ctx *cli.Context) error {
 
 	args := ctx.Args()
 	bbnAddressStr := args.First()
-	if len(bbnAddressStr) == 0 {
-		return errors.New("invalid argument, please provide a valid bbn address as argument")
-	}
-
 	bbnAddr, err := sdk.AccAddressFromBech32(bbnAddressStr)
 	if err != nil {
 		return fmt.Errorf("invalid argument %s, please provide a valid bbn address as argument, err: %w", bbnAddressStr, err)
@@ -131,10 +125,9 @@ func ExportPoP(ctx *cli.Context) error {
 	}
 
 	printRespJSON(PoPExport{
-		PubKeyHex:     pubKey.MarshalHex(),
-		PoP:           pop,
-		PoPHex:        popHex,
-		AddressSigned: bbnAddr.String(),
+		PubKeyHex:      pubKey.MarshalHex(),
+		PoPHex:         popHex,
+		BabylonAddress: bbnAddr.String(),
 	})
 
 	return nil

--- a/eotsmanager/cmd/eotsd/daemon/pop_test.go
+++ b/eotsmanager/cmd/eotsd/daemon/pop_test.go
@@ -1,0 +1,67 @@
+package daemon_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"path/filepath"
+	"testing"
+
+	"github.com/babylonchain/babylon/testutil/datagen"
+	bbn "github.com/babylonchain/babylon/types"
+	dcli "github.com/babylonchain/finality-provider/eotsmanager/cmd/eotsd/daemon"
+	"github.com/babylonchain/finality-provider/testutil"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli"
+)
+
+func FuzzPoPExport(f *testing.F) {
+	testutil.AddRandomSeedsToFuzzer(f, 10)
+	f.Fuzz(func(t *testing.T, seed int64) {
+		r := rand.New(rand.NewSource(seed))
+
+		tempDir := t.TempDir()
+		homeDir := filepath.Join(tempDir, "eots-home")
+		app := testApp()
+
+		// init config in home folder
+		hFlag := fmt.Sprintf("--home=%s", homeDir)
+		err := app.Run([]string{"eotsd", "init", hFlag})
+		require.NoError(t, err)
+
+		keyName := testutil.GenRandomHexStr(r, 10)
+		keyNameFlag := fmt.Sprintf("--key-name=%s", keyName)
+
+		outputKeysAdd := appRunWithOutput(r, t, app, []string{"eotsd", "keys", "add", hFlag, keyNameFlag})
+		keyOutJson := searchInTxt(outputKeysAdd, "for recovery):")
+
+		var keyOut dcli.KeyOutput
+		err = json.Unmarshal([]byte(keyOutJson), &keyOut)
+		require.NoError(t, err)
+
+		bbnAddr := datagen.GenRandomAccount().GetAddress()
+
+		btcPkFlag := fmt.Sprintf("--btc-pk=%s", keyOut.PubKeyHex)
+		exportedPoP := appRunPoPExport(r, t, app, []string{bbnAddr.String(), hFlag, btcPkFlag})
+		require.NotNil(t, exportedPoP)
+		require.NoError(t, exportedPoP.PoP.ValidateBasic())
+
+		btcPubKey, err := bbn.NewBIP340PubKeyFromHex(exportedPoP.PubKeyHex)
+		require.NoError(t, err)
+		require.NoError(t, exportedPoP.PoP.Verify(bbnAddr, btcPubKey, &chaincfg.MainNetParams))
+	})
+}
+
+func appRunPoPExport(r *rand.Rand, t *testing.T, app *cli.App, arguments []string) dcli.PoPExport {
+	args := []string{"eotsd", "pop-export"}
+	args = append(args, arguments...)
+	outputSign := appRunWithOutput(r, t, app, args)
+	signatureStr := searchInTxt(outputSign, "")
+
+	var dataSigned dcli.PoPExport
+	err := json.Unmarshal([]byte(signatureStr), &dataSigned)
+	require.NoError(t, err)
+
+	return dataSigned
+}

--- a/eotsmanager/cmd/eotsd/daemon/pop_test.go
+++ b/eotsmanager/cmd/eotsd/daemon/pop_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/babylonchain/babylon/testutil/datagen"
 	bbn "github.com/babylonchain/babylon/types"
+	btcstktypes "github.com/babylonchain/babylon/x/btcstaking/types"
 	dcli "github.com/babylonchain/finality-provider/eotsmanager/cmd/eotsd/daemon"
 	"github.com/babylonchain/finality-provider/testutil"
 	"github.com/btcsuite/btcd/chaincfg"
@@ -44,12 +45,15 @@ func FuzzPoPExport(f *testing.F) {
 
 		btcPkFlag := fmt.Sprintf("--btc-pk=%s", keyOut.PubKeyHex)
 		exportedPoP := appRunPoPExport(r, t, app, []string{bbnAddr.String(), hFlag, btcPkFlag})
+		pop, err := btcstktypes.NewPoPBTCFromHex(exportedPoP.PoPHex)
+		require.NoError(t, err)
+
 		require.NotNil(t, exportedPoP)
-		require.NoError(t, exportedPoP.PoP.ValidateBasic())
+		require.NoError(t, pop.ValidateBasic())
 
 		btcPubKey, err := bbn.NewBIP340PubKeyFromHex(exportedPoP.PubKeyHex)
 		require.NoError(t, err)
-		require.NoError(t, exportedPoP.PoP.Verify(bbnAddr, btcPubKey, &chaincfg.MainNetParams))
+		require.NoError(t, pop.Verify(bbnAddr, btcPubKey, &chaincfg.SigNetParams))
 	})
 }
 

--- a/eotsmanager/cmd/eotsd/daemon/sign_test.go
+++ b/eotsmanager/cmd/eotsd/daemon/sign_test.go
@@ -149,7 +149,7 @@ func writeFpInfoToFile(r *rand.Rand, t *testing.T, fpInfoPath, btcPk string) {
 func testApp() *cli.App {
 	app := cli.NewApp()
 	app.Name = "eotsd"
-	app.Commands = append(app.Commands, dcli.StartCommand, dcli.InitCommand, dcli.SignSchnorrSig, dcli.VerifySchnorrSig)
+	app.Commands = append(app.Commands, dcli.StartCommand, dcli.InitCommand, dcli.SignSchnorrSig, dcli.VerifySchnorrSig, dcli.ExportPoPCommand)
 	app.Commands = append(app.Commands, dcli.KeysCommands...)
 	return app
 }

--- a/eotsmanager/cmd/eotsd/main.go
+++ b/eotsmanager/cmd/eotsd/main.go
@@ -18,7 +18,10 @@ func main() {
 	app := cli.NewApp()
 	app.Name = "eotsd"
 	app.Usage = "Extractable One Time Signature Daemon (eotsd)."
-	app.Commands = append(app.Commands, dcli.StartCommand, dcli.InitCommand, dcli.SignSchnorrSig, dcli.VerifySchnorrSig)
+	app.Commands = append(
+		app.Commands, dcli.StartCommand, dcli.InitCommand, dcli.SignSchnorrSig, dcli.VerifySchnorrSig,
+		dcli.ExportPoPCommand,
+	)
 	app.Commands = append(app.Commands, dcli.KeysCommands...)
 
 	if err := app.Run(os.Args); err != nil {


### PR DESCRIPTION
This export of proof of possession is useful for building messages like `MsgCreateFinalityProvider`

Add new command `eotsd pop-export [bbn-addr] ... `