### PR TITLE
bump: both fp and `tools` use the same Babylon version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -431,7 +431,7 @@ require (
 replace (
 	// use cosmos fork of keyring
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.2.0
-	github.com/babylonchain/babylon => github.com/babylonchain/babylon-private v0.8.6-0.20240629034230-f5dbfa1d9875
+	github.com/babylonchain/babylon => github.com/babylonchain/babylon-private v0.8.6-0.20240620002950-c5a8d317091e
 	github.com/babylonchain/babylon-da-sdk => github.com/babylonchain/babylon-da-sdk v0.0.0-20240703174540-4746669089a6
 	github.com/cockroachdb/pebble => github.com/cockroachdb/pebble v0.0.0-20231018212520-f6cde3fc2fa4
 	github.com/ethereum-optimism/optimism => github.com/babylonchain/optimism v0.0.0-20240703175008-878e7e6ccc3b

--- a/go.sum
+++ b/go.sum
@@ -298,8 +298,8 @@ github.com/aws/aws-sdk-go v1.44.312/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
 github.com/babylonchain/babylon-da-sdk v0.0.0-20240703174540-4746669089a6 h1:sysWOUVY0w2deUEtxcHivAUOxUoOhT2XvtTxHsZLJG4=
 github.com/babylonchain/babylon-da-sdk v0.0.0-20240703174540-4746669089a6/go.mod h1:s508UvkWTk2jgsuDzpxzXjFxajK4gtJSe6dGFf3eB4E=
-github.com/babylonchain/babylon-private v0.8.6-0.20240629034230-f5dbfa1d9875 h1:Jhi41WKzs0VSRSyu+lkN4rZtW6C03Qs+ZdkkUteg+e8=
-github.com/babylonchain/babylon-private v0.8.6-0.20240629034230-f5dbfa1d9875/go.mod h1:Tdi+29Y+DzCaaz0V0sBRXF1tXXLnH6JHJsOG8uktWLU=
+github.com/babylonchain/babylon-private v0.8.6-0.20240620002950-c5a8d317091e h1:G6jBGu2ySKTsjhShZwJsX1JdNvaYXeeJIHuJba88RDI=
+github.com/babylonchain/babylon-private v0.8.6-0.20240620002950-c5a8d317091e/go.mod h1:Tdi+29Y+DzCaaz0V0sBRXF1tXXLnH6JHJsOG8uktWLU=
 github.com/babylonchain/babylon-sdk/demo v0.0.0-20240624102351-3a809d4fdcce h1:73v+DHCPD4Wi42O2NPJfor+adBiNRkAVddf27idbHrQ=
 github.com/babylonchain/babylon-sdk/demo v0.0.0-20240624102351-3a809d4fdcce/go.mod h1:X4QovCWMwqMjoTriu18w4gfqX1sYqOWRnZwXGYD8bnE=
 github.com/babylonchain/babylon-sdk/x v0.0.0-20240624102351-3a809d4fdcce h1:UYg5QEbMUBt3IIVdcTDXqVTsj1iJoFQBfGC+e6uEtZg=

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -225,6 +225,6 @@ require (
 replace (
 	// use cosmos fork of keyring
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.2.0
-	github.com/babylonchain/babylon => github.com/babylonchain/babylon-private v0.8.6-0.20240618010559-dc7b6269474d
+	github.com/babylonchain/babylon => github.com/babylonchain/babylon-private v0.8.6-0.20240620002950-c5a8d317091e
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 )

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -266,8 +266,8 @@ github.com/aws/aws-sdk-go v1.44.122/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX
 github.com/aws/aws-sdk-go v1.44.312 h1:llrElfzeqG/YOLFFKjg1xNpZCFJ2xraIi3PqSuP+95k=
 github.com/aws/aws-sdk-go v1.44.312/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
-github.com/babylonchain/babylon-private v0.8.6-0.20240618010559-dc7b6269474d h1:rCrkS45Znained3VZvxOEfgWhqC298FypC0PM6A0eFg=
-github.com/babylonchain/babylon-private v0.8.6-0.20240618010559-dc7b6269474d/go.mod h1:Tdi+29Y+DzCaaz0V0sBRXF1tXXLnH6JHJsOG8uktWLU=
+github.com/babylonchain/babylon-private v0.8.6-0.20240620002950-c5a8d317091e h1:G6jBGu2ySKTsjhShZwJsX1JdNvaYXeeJIHuJba88RDI=
+github.com/babylonchain/babylon-private v0.8.6-0.20240620002950-c5a8d317091e/go.mod h1:Tdi+29Y+DzCaaz0V0sBRXF1tXXLnH6JHJsOG8uktWLU=
 github.com/babylonchain/babylon-sdk/demo v0.0.0-20240624102351-3a809d4fdcce h1:73v+DHCPD4Wi42O2NPJfor+adBiNRkAVddf27idbHrQ=
 github.com/babylonchain/babylon-sdk/demo v0.0.0-20240624102351-3a809d4fdcce/go.mod h1:X4QovCWMwqMjoTriu18w4gfqX1sYqOWRnZwXGYD8bnE=
 github.com/babylonchain/babylon-sdk/x v0.0.0-20240624102351-3a809d4fdcce h1:UYg5QEbMUBt3IIVdcTDXqVTsj1iJoFQBfGC+e6uEtZg=


### PR DESCRIPTION
This PR updates the deps in the `go.mod` to ensure finality-provider and the `tools` use [the same version of Babylon](https://github.com/babylonchain/babylon-private/commit/c5a8d317091e2965e20ea56fa10e98d34aaa3547).