### PR TITLE
fix: data race in LocalEOTSManager

### DIFF
--- a/eotsmanager/localmanager.go
+++ b/eotsmanager/localmanager.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/babylonchain/finality-provider/metrics"
 
@@ -31,6 +32,7 @@ const (
 var _ EOTSManager = &LocalEOTSManager{}
 
 type LocalEOTSManager struct {
+	mu     sync.Mutex
 	kr     keyring.Keyring
 	es     *store.EOTSStore
 	logger *zap.Logger
@@ -273,6 +275,8 @@ func (lm *LocalEOTSManager) KeyRecord(fpPk []byte, passphrase string) (*eotstype
 }
 
 func (lm *LocalEOTSManager) getEOTSPrivKey(fpPk []byte, passphrase string) (*btcec.PrivateKey, error) {
+	lm.mu.Lock()
+	defer lm.mu.Unlock()
 	keyName, err := lm.es.GetEOTSKeyName(fpPk)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

while using https://go.dev/doc/articles/race_detector to debug a nasty segfault issue in our own e2e test, we found this issue (https://github.com/babylonchain/finality-provider/issues/478).


## Test Plan
first, add `-race` to the make target for running the e2e tests and run tests

before this PR, I saw:

```
==================
WARNING: DATA RACE
Write at 0x00c0089dfb80 by goroutine 102770:
  strings.(*Reader).Reset()
      /opt/homebrew/Cellar/go/1.22.4/libexec/src/strings/reader.go:156 +0x8c
  github.com/babylonchain/finality-provider/eotsmanager.(*LocalEOTSManager).getEOTSPrivKey()
      /Users/zidong/Documents/Projects/babylon-finality-provider/eotsmanager/localmanager.go:281 +0x6c
  github.com/babylonchain/finality-provider/eotsmanager.(*LocalEOTSManager).KeyRecord()
      /Users/zidong/Documents/Projects/babylon-finality-provider/eotsmanager/localmanager.go:264 +0x84
  github.com/babylonchain/finality-provider/eotsmanager.(*LocalEOTSManager).getRandomnessPair()
      /Users/zidong/Documents/Projects/babylon-finality-provider/eotsmanager/localmanager.go:250 +0x64
  github.com/babylonchain/finality-provider/eotsmanager.(*LocalEOTSManager).CreateRandomnessPairList()
      /Users/zidong/Documents/Projects/babylon-finality-provider/eotsmanager/localmanager.go:173 +0xe0
  github.com/babylonchain/finality-provider/eotsmanager/service.(*rpcServer).CreateRandomnessPairList()
      /Users/zidong/Documents/Projects/babylon-finality-provider/eotsmanager/service/rpcserver.go:59 +0x10c
  github.com/babylonchain/finality-provider/eotsmanager/proto._EOTSManager_CreateRandomnessPairList_Handler()
      /Users/zidong/Documents/Projects/babylon-finality-provider/eotsmanager/proto/eotsmanager_grpc.pb.go:191 +0x248
  google.golang.org/grpc.(*Server).processUnaryRPC()
      /Users/zidong/go/pkg/mod/google.golang.org/grpc@v1.64.0/server.go:1379 +0x1348
  google.golang.org/grpc.(*Server).handleStream()
      /Users/zidong/go/pkg/mod/google.golang.org/grpc@v1.64.0/server.go:1790 +0x11a0
  google.golang.org/grpc.(*Server).serveStreams.func2.1()
      /Users/zidong/go/pkg/mod/google.golang.org/grpc@v1.64.0/server.go:1029 +0xe8

Previous write at 0x00c0089dfb80 by goroutine 102119:
  strings.(*Reader).Reset()
      /opt/homebrew/Cellar/go/1.22.4/libexec/src/strings/reader.go:156 +0x8c
  github.com/babylonchain/finality-provider/eotsmanager.(*LocalEOTSManager).getEOTSPrivKey()
      /Users/zidong/Documents/Projects/babylon-finality-provider/eotsmanager/localmanager.go:281 +0x6c
  github.com/babylonchain/finality-provider/eotsmanager.(*LocalEOTSManager).KeyRecord()
      /Users/zidong/Documents/Projects/babylon-finality-provider/eotsmanager/localmanager.go:264 +0x84
  github.com/babylonchain/finality-provider/eotsmanager.(*LocalEOTSManager).getRandomnessPair()
      /Users/zidong/Documents/Projects/babylon-finality-provider/eotsmanager/localmanager.go:250 +0x64
  github.com/babylonchain/finality-provider/eotsmanager.(*LocalEOTSManager).CreateRandomnessPairList()
      /Users/zidong/Documents/Projects/babylon-finality-provider/eotsmanager/localmanager.go:173 +0xe0
  github.com/babylonchain/finality-provider/eotsmanager/service.(*rpcServer).CreateRandomnessPairList()
      /Users/zidong/Documents/Projects/babylon-finality-provider/eotsmanager/service/rpcserver.go:59 +0x10c
  github.com/babylonchain/finality-provider/eotsmanager/proto._EOTSManager_CreateRandomnessPairList_Handler()
      /Users/zidong/Documents/Projects/babylon-finality-provider/eotsmanager/proto/eotsmanager_grpc.pb.go:191 +0x248
  google.golang.org/grpc.(*Server).processUnaryRPC()
      /Users/zidong/go/pkg/mod/google.golang.org/grpc@v1.64.0/server.go:1379 +0x1348
  google.golang.org/grpc.(*Server).handleStream()
      /Users/zidong/go/pkg/mod/google.golang.org/grpc@v1.64.0/server.go:1790 +0x11a0
  google.golang.org/grpc.(*Server).serveStreams.func2.1()
      /Users/zidong/go/pkg/mod/google.golang.org/grpc@v1.64.0/server.go:1029 +0xe8

Goroutine 102770 (running) created at:
  google.golang.org/grpc.(*Server).serveStreams.func2()
      /Users/zidong/go/pkg/mod/google.golang.org/grpc@v1.64.0/server.go:1040 +0x1e4
  google.golang.org/grpc/internal/transport.(*http2Server).operateHeaders()
      /Users/zidong/go/pkg/mod/google.golang.org/grpc@v1.64.0/internal/transport/http2_server.go:630 +0x2b64
  google.golang.org/grpc/internal/transport.(*http2Server).HandleStreams()
      /Users/zidong/go/pkg/mod/google.golang.org/grpc@v1.64.0/internal/transport/http2_server.go:671 +0x318
  google.golang.org/grpc.(*Server).serveStreams()
      /Users/zidong/go/pkg/mod/google.golang.org/grpc@v1.64.0/server.go:1023 +0x4dc
  google.golang.org/grpc.(*Server).handleRawConn.func1()
      /Users/zidong/go/pkg/mod/google.golang.org/grpc@v1.64.0/server.go:959 +0x7c

Goroutine 102119 (running) created at:
  google.golang.org/grpc.(*Server).serveStreams.func2()
      /Users/zidong/go/pkg/mod/google.golang.org/grpc@v1.64.0/server.go:1040 +0x1e4
  google.golang.org/grpc/internal/transport.(*http2Server).operateHeaders()
      /Users/zidong/go/pkg/mod/google.golang.org/grpc@v1.64.0/internal/transport/http2_server.go:630 +0x2b64
  google.golang.org/grpc/internal/transport.(*http2Server).HandleStreams()
      /Users/zidong/go/pkg/mod/google.golang.org/grpc@v1.64.0/internal/transport/http2_server.go:671 +0x318
  google.golang.org/grpc.(*Server).serveStreams()
      /Users/zidong/go/pkg/mod/google.golang.org/grpc@v1.64.0/server.go:1023 +0x4dc
  google.golang.org/grpc.(*Server).handleRawConn.func1()
      /Users/zidong/go/pkg/mod/google.golang.org/grpc@v1.64.0/server.go:959 +0x7c
==================
```

![image](https://github.com/babylonchain/finality-provider/assets/111917526/110d55e5-d825-4f1b-a3fb-aa3ffbec86e0)

after this PR, no longer see data race in this location
