### PR TITLE
cosmwasm: fix check of activated height in CosmWasm controller

### DIFF
--- a/clientcontroller/cosmwasm/consumer.go
+++ b/clientcontroller/cosmwasm/consumer.go
@@ -246,32 +246,17 @@ func (wc *CosmwasmConsumerController) QueryFinalityProvidersByPower() (*Consumer
 }
 
 func (wc *CosmwasmConsumerController) QueryLatestFinalizedBlock() (*fptypes.BlockInfo, error) {
-	//isFinalized := true
-	//limit := uint64(1)
-	//blocks, err := wc.queryLatestBlocks(nil, &limit, &isFinalized, nil)
-	//if err != nil {
-	//	return nil, err
-	//}
-	//if len(blocks) == 0 {
-	//	return nil, fmt.Errorf("no finalized blocks found")
-	//}
-	//
-	//return blocks[0], nil
+	isFinalized := true
+	limit := uint64(1)
+	blocks, err := wc.queryLatestBlocks(nil, &limit, &isFinalized, nil)
+	if err != nil {
+		return nil, err
+	}
+	if len(blocks) == 0 {
+		return nil, fmt.Errorf("no finalized blocks found")
+	}
 
-	// TODO: temporary hack get the block from comet
-	latestHeight, err := wc.QueryLatestBlockHeight()
-	if err != nil {
-		return nil, err
-	}
-	qHeight := latestHeight / 3
-	if qHeight == 0 {
-		qHeight = 1
-	}
-	block, err := wc.QueryBlock(qHeight)
-	if err != nil {
-		return nil, err
-	}
-	return block, nil
+	return blocks[0], nil
 }
 
 func (wc *CosmwasmConsumerController) QueryBlocks(startHeight, endHeight, limit uint64) ([]*fptypes.BlockInfo, error) {

--- a/clientcontroller/cosmwasm/consumer.go
+++ b/clientcontroller/cosmwasm/consumer.go
@@ -432,21 +432,14 @@ func (wc *CosmwasmConsumerController) QueryLastPublicRandCommit(fpPk *btcec.Publ
 }
 
 func (wc *CosmwasmConsumerController) QueryIsBlockFinalized(height uint64) (bool, error) {
-	//// Use the helper function to get the IndexedBlock
-	//resp, err := wc.QueryIndexedBlock(height)
-	//if err != nil {
-	//	return false, err
-	//}
-	//
-	//// Return the finalized status
-	//return resp.Finalized, nil
-
-	// TODO: temporary hack get the block from comet
-	_, err := wc.queryCometBestBlock()
+	// Use the helper function to get the IndexedBlock
+	resp, err := wc.QueryIndexedBlock(height)
 	if err != nil {
 		return false, err
 	}
-	return true, nil
+
+	// Return the finalized status
+	return resp.Finalized, nil
 }
 
 func (wc *CosmwasmConsumerController) QueryActivatedHeight() (uint64, error) {

--- a/clientcontroller/cosmwasm/consumer.go
+++ b/clientcontroller/cosmwasm/consumer.go
@@ -468,6 +468,9 @@ func (wc *CosmwasmConsumerController) QueryActivatedHeight() (uint64, error) {
 	if err != nil {
 		return 0, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
+	if resp.Height == 0 {
+		return 0, fmt.Errorf("BTC staking is not activated yet")
+	}
 
 	// Return the activated height
 	return resp.Height, nil

--- a/clientcontroller/cosmwasm/consumer.go
+++ b/clientcontroller/cosmwasm/consumer.go
@@ -253,7 +253,9 @@ func (wc *CosmwasmConsumerController) QueryLatestFinalizedBlock() (*fptypes.Bloc
 		return nil, err
 	}
 	if len(blocks) == 0 {
-		return nil, fmt.Errorf("no finalized blocks found")
+		// do not return error here as FP handles this situation by
+		// not running fast sync
+		return nil, nil
 	}
 
 	return blocks[0], nil

--- a/finality-provider/service/chain_poller.go
+++ b/finality-provider/service/chain_poller.go
@@ -210,6 +210,7 @@ func (cp *ChainPoller) waitForActivation() {
 	for {
 		activatedHeight, err := cp.consumerCon.QueryActivatedHeight()
 		if err != nil {
+			// TODO: distinguish between "BTC staking is not activated" and other errors
 			cp.logger.Debug("failed to query the consumer chain for the activated height", zap.Error(err))
 		} else {
 			if cp.nextHeight < activatedHeight {

--- a/finality-provider/service/fp_instance.go
+++ b/finality-provider/service/fp_instance.go
@@ -954,15 +954,15 @@ func (fp *FinalityProviderInstance) getPollerStartingHeight() (uint64, error) {
 	//	(2) The finality providers do not submit signatures for any already
 	//	 finalised blocks.
 	initialBlockToGet := fp.GetLastProcessedHeight()
-	latestFinalisedBlock, err := fp.latestFinalizedBlockWithRetry()
+	latestFinalizedBlock, err := fp.latestFinalizedBlockWithRetry()
 	if err != nil {
 		return 0, err
 	}
 
-	// find max(initialBlockToGet, latestFinalisedBlock.Height)
+	// find max(initialBlockToGet, latestFinalizedBlock.Height)
 	maxHeight := initialBlockToGet
-	if latestFinalisedBlock != nil && latestFinalisedBlock.Height > initialBlockToGet {
-		maxHeight = latestFinalisedBlock.Height
+	if latestFinalizedBlock != nil && latestFinalizedBlock.Height > initialBlockToGet {
+		maxHeight = latestFinalizedBlock.Height
 	}
 
 	return maxHeight + 1, nil
@@ -1015,11 +1015,11 @@ func (fp *FinalityProviderInstance) lastCommittedPublicRandWithRetry() (*types.P
 func (fp *FinalityProviderInstance) latestFinalizedBlockWithRetry() (*types.BlockInfo, error) {
 	var response *types.BlockInfo
 	if err := retry.Do(func() error {
-		latestFinalisedBlock, err := fp.consumerCon.QueryLatestFinalizedBlock()
+		latestFinalizedBlock, err := fp.consumerCon.QueryLatestFinalizedBlock()
 		if err != nil {
 			return err
 		}
-		response = latestFinalisedBlock
+		response = latestFinalizedBlock
 		return nil
 	}, RtyAtt, RtyDel, RtyErr, retry.OnRetry(func(n uint, err error) {
 		fp.logger.Debug(


### PR DESCRIPTION
This PR fixes a bug in CosmWasm consumer controller where we need to check whether the unmarshalled activated height is 0 or not. If it's 0 then it means we are unmarshalling something fishy and actually BTC staking is not activated, and we need to return an error, as [expected](https://github.com/babylonchain/finality-provider/blob/fee9b10e886a098ebd97b7ccfcf9e31bf465a746/finality-provider/service/chain_poller.go#L211-L220) by RPC poller. This fix allows us to remove some hacks and makes e2e / local deployment pass.

@gitferry Do you think in the [poller](https://github.com/babylonchain/finality-provider/blob/a531ebd36686383eb1424929ff95ca820a9b3c5c/finality-provider/service/chain_poller.go#L213-L214) we need to distinguish between the "BTC staking is not activated" and other errors? This seems necessary as it's possible that the errors are some other serious ones, rather than that BTC staking is not activated.