### PR TITLE
test: split into FP registration and FP instance startup in the op test manager

### DIFF
--- a/itest/opstackl2/op_e2e_test.go
+++ b/itest/opstackl2/op_e2e_test.go
@@ -19,7 +19,7 @@ func TestOpSubmitFinalitySignature(t *testing.T) {
 	ctm := StartOpL2ConsumerManager(t)
 	defer ctm.Stop(t)
 
-	consumerFpPkList := ctm.RegisterFinalityProvider(t, ctm.getConsumerChainId(), 1)
+	consumerFpPkList := ctm.RegisterConsumerFinalityProvider(t, ctm.getConsumerChainId(), 1)
 	// start consumer chain FP
 	fpList := ctm.StartConsumerFinalityProvider(t, consumerFpPkList)
 	fpInstance := fpList[0]
@@ -61,7 +61,7 @@ func TestOpMultipleFinalityProviders(t *testing.T) {
 
 	// start consumer chain FP
 	n := 2
-	consumerFpPkList := ctm.RegisterFinalityProvider(t, ctm.getConsumerChainId(), n)
+	consumerFpPkList := ctm.RegisterConsumerFinalityProvider(t, ctm.getConsumerChainId(), n)
 	fpList := ctm.StartConsumerFinalityProvider(t, consumerFpPkList)
 
 	// check the public randomness is committed

--- a/itest/opstackl2/op_e2e_test.go
+++ b/itest/opstackl2/op_e2e_test.go
@@ -19,8 +19,9 @@ func TestOpSubmitFinalitySignature(t *testing.T) {
 	ctm := StartOpL2ConsumerManager(t)
 	defer ctm.Stop(t)
 
+	consumerFpPkList := ctm.RegisterFinalityProvider(t, ctm.getConsumerChainId(), 1)
 	// start consumer chain FP
-	fpList := ctm.StartFinalityProvider(t, 1)
+	fpList := ctm.StartConsumerFinalityProvider(t, consumerFpPkList)
 	fpInstance := fpList[0]
 
 	e2eutils.WaitForFpPubRandCommitted(t, fpInstance)
@@ -56,11 +57,12 @@ func TestOpMultipleFinalityProviders(t *testing.T) {
 	// A BTC delegation has to stake to at least one Babylon finality provider
 	// https://github.com/babylonchain/babylon-private/blob/base/consumer-chain-support/x/btcstaking/keeper/msg_server.go#L169-L213
 	// So we have to start Babylon chain FP
-	bbnFpPk := ctm.RegisterBBNFinalityProvider(t)
+	bbnFpPk := ctm.RegisterFinalityProvider(t, e2eutils.ChainID, 1)
 
 	// start consumer chain FP
 	n := 2
-	fpList := ctm.StartFinalityProvider(t, n)
+	consumerFpPkList := ctm.RegisterFinalityProvider(t, ctm.getConsumerChainId(), n)
+	fpList := ctm.StartConsumerFinalityProvider(t, consumerFpPkList)
 
 	// check the public randomness is committed
 	e2eutils.WaitForFpPubRandCommitted(t, fpList[0])
@@ -68,8 +70,8 @@ func TestOpMultipleFinalityProviders(t *testing.T) {
 
 	// send a BTC delegation to consumer and Babylon finality providers
 	// for the first FP, we give it more power b/c it will be used later
-	ctm.InsertBTCDelegation(t, []*btcec.PublicKey{bbnFpPk, fpList[0].GetBtcPk()}, e2eutils.StakingTime, 3*e2eutils.StakingAmount)
-	ctm.InsertBTCDelegation(t, []*btcec.PublicKey{bbnFpPk, fpList[1].GetBtcPk()}, e2eutils.StakingTime, e2eutils.StakingAmount)
+	ctm.InsertBTCDelegation(t, []*btcec.PublicKey{bbnFpPk[0].MustToBTCPK(), consumerFpPkList[0].MustToBTCPK()}, e2eutils.StakingTime, 3*e2eutils.StakingAmount)
+	ctm.InsertBTCDelegation(t, []*btcec.PublicKey{bbnFpPk[0].MustToBTCPK(), consumerFpPkList[1].MustToBTCPK()}, e2eutils.StakingTime, e2eutils.StakingAmount)
 
 	// check the BTC delegations are pending
 	delsResp := ctm.WaitForNPendingDels(t, n)

--- a/itest/opstackl2/op_e2e_test.go
+++ b/itest/opstackl2/op_e2e_test.go
@@ -19,7 +19,7 @@ func TestOpSubmitFinalitySignature(t *testing.T) {
 	ctm := StartOpL2ConsumerManager(t)
 	defer ctm.Stop(t)
 
-	consumerFpPkList := ctm.RegisterConsumerFinalityProvider(t, ctm.getConsumerChainId(), 1)
+	consumerFpPkList := ctm.RegisterConsumerFinalityProvider(t, 1)
 	// start consumer chain FP
 	fpList := ctm.StartConsumerFinalityProvider(t, consumerFpPkList)
 	fpInstance := fpList[0]
@@ -57,11 +57,11 @@ func TestOpMultipleFinalityProviders(t *testing.T) {
 	// A BTC delegation has to stake to at least one Babylon finality provider
 	// https://github.com/babylonchain/babylon-private/blob/base/consumer-chain-support/x/btcstaking/keeper/msg_server.go#L169-L213
 	// So we have to start Babylon chain FP
-	bbnFpPk := ctm.RegisterFinalityProvider(t, e2eutils.ChainID, 1)
+	bbnFpPk := ctm.RegisterBabylonFinalityProvider(t, 1)
 
 	// start consumer chain FP
 	n := 2
-	consumerFpPkList := ctm.RegisterConsumerFinalityProvider(t, ctm.getConsumerChainId(), n)
+	consumerFpPkList := ctm.RegisterConsumerFinalityProvider(t, n)
 	fpList := ctm.StartConsumerFinalityProvider(t, consumerFpPkList)
 
 	// check the public randomness is committed

--- a/itest/opstackl2/op_test_manager.go
+++ b/itest/opstackl2/op_test_manager.go
@@ -328,10 +328,10 @@ func (ctm *OpL2ConsumerTestManager) WaitForTargetBlockPubRand(t *testing.T, fpLi
 }
 
 // can be used for both the Babylon and Consumer FPs
-func (ctm *OpL2ConsumerTestManager) RegisterFinalityProvider(t *testing.T, chainId string, n int) []*bbntypes.BIP340PubKey {
+func (ctm *OpL2ConsumerTestManager) registerFinalityProvider(t *testing.T, consumerID string, n int) []*bbntypes.BIP340PubKey {
 	app := ctm.FpApp
-	baseFpName := fmt.Sprintf("%s-%s", chainId, e2eutils.FpNamePrefix)
-	baseMoniker := fmt.Sprintf("%s-%s", chainId, e2eutils.MonikerPrefix)
+	baseFpName := fmt.Sprintf("%s-%s", consumerID, e2eutils.FpNamePrefix)
+	baseMoniker := fmt.Sprintf("%s-%s", consumerID, e2eutils.MonikerPrefix)
 	fpPkList := make([]*bbntypes.BIP340PubKey, 0, n)
 
 	for i := 0; i < n; i++ {
@@ -343,20 +343,20 @@ func (ctm *OpL2ConsumerTestManager) RegisterFinalityProvider(t *testing.T, chain
 		cfg := app.GetConfig()
 		_, err := service.CreateChainKey(cfg.BabylonConfig.KeyDirectory, cfg.BabylonConfig.ChainID, fpName, keyring.BackendTest, e2eutils.Passphrase, e2eutils.HdPath, "")
 		require.NoError(t, err)
-		res, err := app.CreateFinalityProvider(fpName, chainId, e2eutils.Passphrase, e2eutils.HdPath, desc, &commission)
+		res, err := app.CreateFinalityProvider(fpName, consumerID, e2eutils.Passphrase, e2eutils.HdPath, desc, &commission)
 		require.NoError(t, err)
 		fpPk, err := bbntypes.NewBIP340PubKeyFromHex(res.FpInfo.BtcPkHex)
 		require.NoError(t, err)
 		_, err = app.RegisterFinalityProvider(fpPk.MarshalHex())
 		require.NoError(t, err)
 		fpPkList = append(fpPkList, fpPk)
-		log.Logf(t, "Registered Finality Provider %s for %s", fpPk.MarshalHex(), chainId)
+		log.Logf(t, "Registered Finality Provider %s for %s", fpPk.MarshalHex(), consumerID)
 	}
 
 	return fpPkList
 }
 
-func (ctm *OpL2ConsumerTestManager) WaitForConsumerFPRegistration(t *testing.T, n int) {
+func (ctm *OpL2ConsumerTestManager) waitForConsumerFPRegistration(t *testing.T, n int) {
 	require.Eventually(t, func() bool {
 		fps, err := ctm.BBNClient.QueryConsumerFinalityProviders(ctm.getConsumerChainId())
 		if err != nil {
@@ -371,12 +371,12 @@ func (ctm *OpL2ConsumerTestManager) WaitForConsumerFPRegistration(t *testing.T, 
 }
 
 func (ctm *OpL2ConsumerTestManager) RegisterConsumerFinalityProvider(t *testing.T, n int) []*bbntypes.BIP340PubKey {
-	consumerFpPkList := ctm.RegisterFinalityProvider(t, ctm.getConsumerChainId(), n)
-	ctm.WaitForConsumerFPRegistration(t, n)
+	consumerFpPkList := ctm.registerFinalityProvider(t, ctm.getConsumerChainId(), n)
+	ctm.waitForConsumerFPRegistration(t, n)
 	return consumerFpPkList
 }
 
-func (ctm *OpL2ConsumerTestManager) WaitForBabylonFPRegistration(t *testing.T, n int) {
+func (ctm *OpL2ConsumerTestManager) waitForBabylonFPRegistration(t *testing.T, n int) {
 	require.Eventually(t, func() bool {
 		fps, err := ctm.BBNClient.QueryFinalityProviders()
 		if err != nil {
@@ -391,8 +391,8 @@ func (ctm *OpL2ConsumerTestManager) WaitForBabylonFPRegistration(t *testing.T, n
 }
 
 func (ctm *OpL2ConsumerTestManager) RegisterBabylonFinalityProvider(t *testing.T, n int) []*bbntypes.BIP340PubKey {
-	babylonFpPkList := ctm.RegisterFinalityProvider(t, e2eutils.ChainID, n)
-	ctm.WaitForBabylonFPRegistration(t, n)
+	babylonFpPkList := ctm.registerFinalityProvider(t, e2eutils.ChainID, n)
+	ctm.waitForBabylonFPRegistration(t, n)
 	return babylonFpPkList
 }
 

--- a/itest/opstackl2/op_test_manager.go
+++ b/itest/opstackl2/op_test_manager.go
@@ -356,9 +356,9 @@ func (ctm *OpL2ConsumerTestManager) RegisterFinalityProvider(t *testing.T, chain
 	return fpPkList
 }
 
-func (ctm *OpL2ConsumerTestManager) WaitForConsumerFPRegistration(t *testing.T, chainId string, n int) {
+func (ctm *OpL2ConsumerTestManager) WaitForConsumerFPRegistration(t *testing.T, n int) {
 	require.Eventually(t, func() bool {
-		fps, err := ctm.BBNClient.QueryConsumerFinalityProviders(chainId)
+		fps, err := ctm.BBNClient.QueryConsumerFinalityProviders(ctm.getConsumerChainId())
 		if err != nil {
 			log.Logf(t, "failed to query consumer FP(s) from Babylon %s", err.Error())
 			return false
@@ -370,10 +370,30 @@ func (ctm *OpL2ConsumerTestManager) WaitForConsumerFPRegistration(t *testing.T, 
 	}, e2eutils.EventuallyWaitTimeOut, e2eutils.EventuallyPollTime)
 }
 
-func (ctm *OpL2ConsumerTestManager) RegisterConsumerFinalityProvider(t *testing.T, chainId string, n int) []*bbntypes.BIP340PubKey {
+func (ctm *OpL2ConsumerTestManager) RegisterConsumerFinalityProvider(t *testing.T, n int) []*bbntypes.BIP340PubKey {
 	consumerFpPkList := ctm.RegisterFinalityProvider(t, ctm.getConsumerChainId(), n)
-	ctm.WaitForConsumerFPRegistration(t, ctm.getConsumerChainId(), n)
+	ctm.WaitForConsumerFPRegistration(t, n)
 	return consumerFpPkList
+}
+
+func (ctm *OpL2ConsumerTestManager) WaitForBabylonFPRegistration(t *testing.T, n int) {
+	require.Eventually(t, func() bool {
+		fps, err := ctm.BBNClient.QueryFinalityProviders()
+		if err != nil {
+			log.Logf(t, "failed to query Babylon FP(s) from Babylon %s", err.Error())
+			return false
+		}
+		if len(fps) != n {
+			return false
+		}
+		return true
+	}, e2eutils.EventuallyWaitTimeOut, e2eutils.EventuallyPollTime)
+}
+
+func (ctm *OpL2ConsumerTestManager) RegisterBabylonFinalityProvider(t *testing.T, n int) []*bbntypes.BIP340PubKey {
+	babylonFpPkList := ctm.RegisterFinalityProvider(t, e2eutils.ChainID, n)
+	ctm.WaitForBabylonFPRegistration(t, n)
+	return babylonFpPkList
 }
 
 func (ctm *OpL2ConsumerTestManager) getConsumerChainId() string {


### PR DESCRIPTION
This PR splits into FP registration and FP instance startup in the op test manager. It is needed for the next test case: https://github.com/babylonchain/finality-provider/issues/502

## Test Plan

```
make test-e2e-op
```