### PR TITLE
test: check L2 finality will get stuck if one block didn't get enough votes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ test-e2e-wasmd: clean-e2e install-babylond install-wasmd
 	@go test -mod=readonly -timeout=25m -v $(PACKAGES_E2E) -count=1 --tags=e2e_wasmd
 
 test-e2e-op: clean-e2e install-babylond
-	@go test -mod=readonly -timeout=25m -v $(PACKAGES_E2E_OP) -count=1 --tags=e2e_op
+	@go test -mod=readonly -timeout=25m -v $(PACKAGES_E2E_OP) -count=1 --tags=e2e_op --run ^TestOpchainStuckAndRecover$
 
 DEVNET_REPO_URL := https://github.com/babylonchain/op-e2e-devnet
 TARGET_DIR := ./itest/opstackl2/devnet-data

--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ test-e2e-wasmd: clean-e2e install-babylond install-wasmd
 	@go test -mod=readonly -timeout=25m -v $(PACKAGES_E2E) -count=1 --tags=e2e_wasmd
 
 test-e2e-op: clean-e2e install-babylond
-	@go test -mod=readonly -timeout=25m -v $(PACKAGES_E2E_OP) -count=1 --tags=e2e_op --run ^TestOpchainStuckAndRecover$
+	@go test -mod=readonly -timeout=25m -v $(PACKAGES_E2E_OP) -count=1 --tags=e2e_op
 
 DEVNET_REPO_URL := https://github.com/babylonchain/op-e2e-devnet
 TARGET_DIR := ./itest/opstackl2/devnet-data

--- a/itest/opstackl2/op_e2e_test.go
+++ b/itest/opstackl2/op_e2e_test.go
@@ -19,7 +19,7 @@ func TestOpSubmitFinalitySignature(t *testing.T) {
 	ctm := StartOpL2ConsumerManager(t)
 	defer ctm.Stop(t)
 
-	consumerFpPkList := ctm.RegisterFinalityProvider(t, ctm.getConsumerChainId(), 1)
+	consumerFpPkList := ctm.RegisterConsumerFinalityProvider(t, ctm.getConsumerChainId(), 1)
 	// start consumer chain FP
 	fpList := ctm.StartConsumerFinalityProvider(t, consumerFpPkList)
 	fpInstance := fpList[0]
@@ -61,7 +61,7 @@ func TestOpMultipleFinalityProviders(t *testing.T) {
 
 	// start consumer chain FP
 	n := 2
-	consumerFpPkList := ctm.RegisterFinalityProvider(t, ctm.getConsumerChainId(), n)
+	consumerFpPkList := ctm.RegisterConsumerFinalityProvider(t, ctm.getConsumerChainId(), n)
 	fpList := ctm.StartConsumerFinalityProvider(t, consumerFpPkList)
 
 	// check the public randomness is committed

--- a/itest/opstackl2/op_e2e_test.go
+++ b/itest/opstackl2/op_e2e_test.go
@@ -19,8 +19,9 @@ func TestOpSubmitFinalitySignature(t *testing.T) {
 	ctm := StartOpL2ConsumerManager(t)
 	defer ctm.Stop(t)
 
+	consumerFpPkList := ctm.RegisterFinalityProvider(t, ctm.getConsumerChainId(), 1)
 	// start consumer chain FP
-	fpList := ctm.StartFinalityProvider(t, 1)
+	fpList := ctm.StartConsumerFinalityProvider(t, consumerFpPkList)
 	fpInstance := fpList[0]
 
 	e2eutils.WaitForFpPubRandCommitted(t, fpInstance)
@@ -56,11 +57,12 @@ func TestOpMultipleFinalityProviders(t *testing.T) {
 	// A BTC delegation has to stake to at least one Babylon finality provider
 	// https://github.com/babylonchain/babylon-private/blob/base/consumer-chain-support/x/btcstaking/keeper/msg_server.go#L169-L213
 	// So we have to start Babylon chain FP
-	bbnFpPk := ctm.RegisterBBNFinalityProvider(t)
+	bbnFpPk := ctm.RegisterFinalityProvider(t, e2eutils.ChainID, 1)
 
 	// start consumer chain FP
 	n := 2
-	fpList := ctm.StartFinalityProvider(t, n)
+	consumerFpPkList := ctm.RegisterFinalityProvider(t, ctm.getConsumerChainId(), n)
+	fpList := ctm.StartConsumerFinalityProvider(t, consumerFpPkList)
 
 	// check the public randomness is committed
 	e2eutils.WaitForFpPubRandCommitted(t, fpList[0])
@@ -68,8 +70,8 @@ func TestOpMultipleFinalityProviders(t *testing.T) {
 
 	// send a BTC delegation to consumer and Babylon finality providers
 	// for the first FP, we give it more power b/c it will be used later
-	ctm.InsertBTCDelegation(t, []*btcec.PublicKey{bbnFpPk, fpList[0].GetBtcPk()}, e2eutils.StakingTime, 3*e2eutils.StakingAmount)
-	ctm.InsertBTCDelegation(t, []*btcec.PublicKey{bbnFpPk, fpList[1].GetBtcPk()}, e2eutils.StakingTime, e2eutils.StakingAmount)
+	ctm.InsertBTCDelegation(t, []*btcec.PublicKey{bbnFpPk[0].MustToBTCPK(), consumerFpPkList[0].MustToBTCPK()}, e2eutils.StakingTime, 3*e2eutils.StakingAmount)
+	ctm.InsertBTCDelegation(t, []*btcec.PublicKey{bbnFpPk[0].MustToBTCPK(), consumerFpPkList[1].MustToBTCPK()}, e2eutils.StakingTime, e2eutils.StakingAmount)
 
 	// check the BTC delegations are pending
 	delsResp := ctm.WaitForNPendingDels(t, n)

--- a/itest/opstackl2/op_e2e_test.go
+++ b/itest/opstackl2/op_e2e_test.go
@@ -165,7 +165,7 @@ func TestOpchainStuckAndRecover(t *testing.T) {
 	// check the BTC delegations are active
 	ctm.WaitForNActiveDels(t, n)
 
-	blockHeight := ctm.WaitForOpchainStuck(t)
+	blockHeight := ctm.WaitForOpChainStuck(t)
 	log.Logf(t, "Test case 1: OP chain is stuck at block %d", blockHeight)
 
 	// ===  another test case: recover op chain ===

--- a/itest/opstackl2/op_e2e_test.go
+++ b/itest/opstackl2/op_e2e_test.go
@@ -19,7 +19,7 @@ func TestOpSubmitFinalitySignature(t *testing.T) {
 	ctm := StartOpL2ConsumerManager(t)
 	defer ctm.Stop(t)
 
-	consumerFpPkList := ctm.RegisterConsumerFinalityProvider(t, ctm.getConsumerChainId(), 1)
+	consumerFpPkList := ctm.RegisterConsumerFinalityProvider(t, 1)
 	// start consumer chain FP
 	fpList := ctm.StartConsumerFinalityProvider(t, consumerFpPkList)
 	fpInstance := fpList[0]
@@ -57,11 +57,11 @@ func TestOpMultipleFinalityProviders(t *testing.T) {
 	// A BTC delegation has to stake to at least one Babylon finality provider
 	// https://github.com/babylonchain/babylon-private/blob/base/consumer-chain-support/x/btcstaking/keeper/msg_server.go#L169-L213
 	// So we have to start Babylon chain FP
-	bbnFpPk := ctm.RegisterFinalityProvider(t, e2eutils.ChainID, 1)
+	bbnFpPk := ctm.RegisterBabylonFinalityProvider(t, 1)
 
 	// start consumer chain FP
 	n := 2
-	consumerFpPkList := ctm.RegisterConsumerFinalityProvider(t, ctm.getConsumerChainId(), n)
+	consumerFpPkList := ctm.RegisterConsumerFinalityProvider(t, n)
 	fpList := ctm.StartConsumerFinalityProvider(t, consumerFpPkList)
 
 	// check the public randomness is committed

--- a/itest/opstackl2/op_e2e_test.go
+++ b/itest/opstackl2/op_e2e_test.go
@@ -188,9 +188,9 @@ func TestFinalityStuckAndRecover(t *testing.T) {
 	t.Logf("last processed height %d", lastProcessedHeight)
 	time.Sleep(5 * L2BlockTime)
 	// check the finality is stuck
-	checkFinalizedBlock, err := ctm.OpL2ConsumerCtrl.QueryLatestFinalizedBlock()
+	latestFinalizedBlock, err := ctm.OpL2ConsumerCtrl.QueryLatestFinalizedBlock()
 	require.NoError(t, err)
-	stuckHeight := checkFinalizedBlock.Height
+	stuckHeight := latestFinalizedBlock.Height
 	require.Equal(t, lastProcessedHeight, stuckHeight)
 	t.Logf("Test case 1: OP chain block finalized stuck at height %d", stuckHeight)
 

--- a/itest/opstackl2/op_test_manager.go
+++ b/itest/opstackl2/op_test_manager.go
@@ -411,45 +411,17 @@ func (ctm *OpL2ConsumerTestManager) WaitForFianlizedBlock(t *testing.T, checkedH
 	return finalizedBlockHeight
 }
 
-func (ctm *OpL2ConsumerTestManager) getFianlizedInterval(t *testing.T) float64 {
-	averageTime := float64(0)
-	finalizedBlock, err := ctm.OpL2ConsumerCtrl.QueryLatestFinalizedBlock()
-	require.NoError(t, err)
-	currentTime := time.Now().Unix()
-	t.Logf("Test case 1: current finalized block height %d, %d", finalizedBlock.Height, currentTime)
-	require.Eventually(t, func() bool {
-		nextFinalizedBlock, err := ctm.OpL2ConsumerCtrl.QueryLatestFinalizedBlock()
-		require.NoError(t, err)
-		nextTime := time.Now().Unix()
-		t.Logf("Test case 1: next finalized block height %d, %d", nextFinalizedBlock.Height, nextTime)
-		blockAmount := nextFinalizedBlock.Height - finalizedBlock.Height
-		require.NotEqual(t, 0, blockAmount, "finalized block amount should not be 0")
-		if blockAmount > 0 {
-			t.Logf("Test case 1: block amount %d", blockAmount)
-			averageTime = float64(nextTime-currentTime) / float64(blockAmount)
-			return true
-		}
-		return false
-	}, e2eutils.EventuallyWaitTimeOut, 5*L2BlockTime)
-	t.Logf("Test case 1: finalized block average time %f", averageTime)
-	return averageTime
-}
-
-func (ctm *OpL2ConsumerTestManager) WaitForGetFianlizedInterval(t *testing.T, fpInstance *service.FinalityProviderInstance) float64 {
-	finalizedInterval := float64(0)
+func (ctm *OpL2ConsumerTestManager) WaitForNonFastSync(t *testing.T, fpInstance *service.FinalityProviderInstance) {
 	require.Eventually(t, func() bool {
 		latestBlockHeight, err := ctm.OpL2ConsumerCtrl.QueryLatestBlockHeight()
 		require.NoError(t, err)
 		lastProcessedHeight := fpInstance.GetLastProcessedHeight()
-		// wait until non fast sync
 		if latestBlockHeight < lastProcessedHeight+ctm.FpConfig.FastSyncGap {
-			t.Logf("Test case 1: latestBlockHeight %d and lastProcessedHeight %d", latestBlockHeight, lastProcessedHeight)
-			finalizedInterval = ctm.getFianlizedInterval(t)
+			t.Logf("Non fast sync, latest block height %d and last processed height %d", latestBlockHeight, lastProcessedHeight)
 			return true
 		}
 		return false
 	}, e2eutils.EventuallyWaitTimeOut, L2BlockTime)
-	return finalizedInterval
 }
 
 func (ctm *OpL2ConsumerTestManager) getConsumerChainId() string {

--- a/itest/opstackl2/op_test_manager.go
+++ b/itest/opstackl2/op_test_manager.go
@@ -403,10 +403,7 @@ func (ctm *OpL2ConsumerTestManager) WaitForFianlizedBlock(t *testing.T, checkedH
 		nextFinalizedBlock, err := ctm.OpL2ConsumerCtrl.QueryLatestFinalizedBlock()
 		require.NoError(t, err)
 		finalizedBlockHeight = nextFinalizedBlock.Height
-		if finalizedBlockHeight > checkedHeight {
-			return true
-		}
-		return false
+		return finalizedBlockHeight > checkedHeight
 	}, e2eutils.EventuallyWaitTimeOut, 5*L2BlockTime)
 	return finalizedBlockHeight
 }

--- a/itest/opstackl2/op_test_manager.go
+++ b/itest/opstackl2/op_test_manager.go
@@ -68,7 +68,7 @@ func StartOpL2ConsumerManager(t *testing.T) *OpL2ConsumerTestManager {
 	testDir, err := e2eutils.BaseDir("fpe2etest")
 	require.NoError(t, err)
 
-	logger := createLogger(t, zapcore.ErrorLevel)
+	logger := createLogger(t, zapcore.DebugLevel)
 
 	// generate covenant committee
 	covenantQuorum := 2
@@ -87,7 +87,6 @@ func StartOpL2ConsumerManager(t *testing.T) *OpL2ConsumerTestManager {
 	cfg.RandomnessCommitInterval = 2 * time.Second
 	cfg.NumPubRand = 64
 	cfg.MinRandHeightGap = 1000
-	cfg.FastSyncGap = 30
 	bc, err := bbncc.NewBabylonController(cfg.BabylonConfig, &cfg.BTCNetParams, logger)
 	require.NoError(t, err)
 
@@ -397,7 +396,7 @@ func (ctm *OpL2ConsumerTestManager) RegisterBabylonFinalityProvider(t *testing.T
 	return babylonFpPkList
 }
 
-func (ctm *OpL2ConsumerTestManager) WaitForFinalizedBlock(t *testing.T, checkedHeight uint64) uint64 {
+func (ctm *OpL2ConsumerTestManager) WaitForNextFinalizedBlock(t *testing.T, checkedHeight uint64) uint64 {
 	finalizedBlockHeight := uint64(0)
 	require.Eventually(t, func() bool {
 		nextFinalizedBlock, err := ctm.OpL2ConsumerCtrl.QueryLatestFinalizedBlock()
@@ -406,36 +405,6 @@ func (ctm *OpL2ConsumerTestManager) WaitForFinalizedBlock(t *testing.T, checkedH
 		return finalizedBlockHeight > checkedHeight
 	}, e2eutils.EventuallyWaitTimeOut, 5*L2BlockTime)
 	return finalizedBlockHeight
-}
-
-func (ctm *OpL2ConsumerTestManager) WaitForFinalityStuck(t *testing.T) uint64 {
-	finalizedBlock, err := ctm.OpL2ConsumerCtrl.QueryLatestFinalizedBlock()
-	require.NoError(t, err)
-	stuckHeight := finalizedBlock.Height
-	require.Eventually(t, func() bool {
-		checkFinalizedBlock, err := ctm.OpL2ConsumerCtrl.QueryLatestFinalizedBlock()
-		require.NoError(t, err)
-		checkFinalizedBlockHeight := checkFinalizedBlock.Height
-		if checkFinalizedBlockHeight > stuckHeight {
-			stuckHeight = checkFinalizedBlock.Height
-			return false
-		}
-		return stuckHeight == checkFinalizedBlockHeight
-	}, e2eutils.EventuallyWaitTimeOut, 5*L2BlockTime)
-	return stuckHeight
-}
-
-func (ctm *OpL2ConsumerTestManager) WaitForNonFastSync(t *testing.T, fpInstance *service.FinalityProviderInstance) {
-	require.Eventually(t, func() bool {
-		latestBlockHeight, err := ctm.OpL2ConsumerCtrl.QueryLatestBlockHeight()
-		require.NoError(t, err)
-		lastProcessedHeight := fpInstance.GetLastProcessedHeight()
-		if latestBlockHeight < lastProcessedHeight+ctm.FpConfig.FastSyncGap {
-			t.Logf("Non fast sync, latest block height %d and last processed height %d", latestBlockHeight, lastProcessedHeight)
-			return true
-		}
-		return false
-	}, e2eutils.EventuallyWaitTimeOut, L2BlockTime)
 }
 
 func (ctm *OpL2ConsumerTestManager) getConsumerChainId() string {

--- a/itest/opstackl2/op_test_manager.go
+++ b/itest/opstackl2/op_test_manager.go
@@ -396,6 +396,22 @@ func (ctm *OpL2ConsumerTestManager) RegisterBabylonFinalityProvider(t *testing.T
 	return babylonFpPkList
 }
 
+func (ctm *OpL2ConsumerTestManager) WaitForOpchainStuck(t *testing.T) uint64 {
+	blockHeight := uint64(0)
+	require.Eventually(t, func() bool {
+		finalizedBlock, err := ctm.OpL2ConsumerCtrl.QueryLatestFinalizedBlock()
+		require.NoError(t, err)
+		latestBlockHeight, err := ctm.OpL2ConsumerCtrl.QueryLatestBlockHeight()
+		require.NoError(t, err)
+		if finalizedBlock.Height == 0 && blockHeight == latestBlockHeight {
+			return true
+		}
+		blockHeight = latestBlockHeight
+		return false
+	}, e2eutils.EventuallyWaitTimeOut, e2eutils.EventuallyPollTime)
+	return blockHeight
+}
+
 func (ctm *OpL2ConsumerTestManager) getConsumerChainId() string {
 	l2ChainId := ctm.OpSystem.Cfg.DeployConfig.L2ChainID
 	return fmt.Sprintf("%s%d", consumerChainIdPrefix, l2ChainId)

--- a/itest/opstackl2/op_test_manager.go
+++ b/itest/opstackl2/op_test_manager.go
@@ -356,9 +356,9 @@ func (ctm *OpL2ConsumerTestManager) RegisterFinalityProvider(t *testing.T, chain
 	return fpPkList
 }
 
-func (ctm *OpL2ConsumerTestManager) WaitForConsumerFPRegistration(t *testing.T, chainId string, n int) {
+func (ctm *OpL2ConsumerTestManager) WaitForConsumerFPRegistration(t *testing.T, n int) {
 	require.Eventually(t, func() bool {
-		fps, err := ctm.BBNClient.QueryConsumerFinalityProviders(chainId)
+		fps, err := ctm.BBNClient.QueryConsumerFinalityProviders(ctm.getConsumerChainId())
 		if err != nil {
 			log.Logf(t, "failed to query consumer FP(s) from Babylon %s", err.Error())
 			return false
@@ -370,10 +370,30 @@ func (ctm *OpL2ConsumerTestManager) WaitForConsumerFPRegistration(t *testing.T, 
 	}, e2eutils.EventuallyWaitTimeOut, e2eutils.EventuallyPollTime)
 }
 
-func (ctm *OpL2ConsumerTestManager) RegisterConsumerFinalityProvider(t *testing.T, chainId string, n int) []*bbntypes.BIP340PubKey {
+func (ctm *OpL2ConsumerTestManager) RegisterConsumerFinalityProvider(t *testing.T, n int) []*bbntypes.BIP340PubKey {
 	consumerFpPkList := ctm.RegisterFinalityProvider(t, ctm.getConsumerChainId(), n)
-	ctm.WaitForConsumerFPRegistration(t, ctm.getConsumerChainId(), n)
+	ctm.WaitForConsumerFPRegistration(t, n)
 	return consumerFpPkList
+}
+
+func (ctm *OpL2ConsumerTestManager) WaitForBabylonFPRegistration(t *testing.T, n int) {
+	require.Eventually(t, func() bool {
+		fps, err := ctm.BBNClient.QueryFinalityProviders()
+		if err != nil {
+			log.Logf(t, "failed to query Babylon FP(s) from Babylon %s", err.Error())
+			return false
+		}
+		if len(fps) != n {
+			return false
+		}
+		return true
+	}, e2eutils.EventuallyWaitTimeOut, e2eutils.EventuallyPollTime)
+}
+
+func (ctm *OpL2ConsumerTestManager) RegisterBabylonFinalityProvider(t *testing.T, n int) []*bbntypes.BIP340PubKey {
+	babylonFpPkList := ctm.RegisterFinalityProvider(t, e2eutils.ChainID, n)
+	ctm.WaitForBabylonFPRegistration(t, n)
+	return babylonFpPkList
 }
 
 func (ctm *OpL2ConsumerTestManager) getConsumerChainId() string {

--- a/itest/opstackl2/op_test_manager.go
+++ b/itest/opstackl2/op_test_manager.go
@@ -396,6 +396,23 @@ func (ctm *OpL2ConsumerTestManager) RegisterBabylonFinalityProvider(t *testing.T
 	return babylonFpPkList
 }
 
+func (ctm *OpL2ConsumerTestManager) WaitForOpchainStuck(t *testing.T) {
+	blockHeight := uint64(0)
+	require.Eventually(t, func() bool {
+		finalizedBlock, err := ctm.OpL2ConsumerCtrl.QueryLatestFinalizedBlock()
+		require.NoError(t, err)
+		t.Logf("finalized block height: %d", finalizedBlock.Height)
+		latestBlockHeight, err := ctm.OpL2ConsumerCtrl.QueryLatestBlockHeight()
+		require.NoError(t, err)
+		t.Logf("latest block height: %d", latestBlockHeight)
+		if finalizedBlock.Height == 0 && blockHeight == latestBlockHeight {
+			return true
+		}
+		blockHeight = latestBlockHeight
+		return false
+	}, e2eutils.EventuallyWaitTimeOut, e2eutils.EventuallyPollTime)
+}
+
 func (ctm *OpL2ConsumerTestManager) getConsumerChainId() string {
 	l2ChainId := ctm.OpSystem.Cfg.DeployConfig.L2ChainID
 	return fmt.Sprintf("%s%d", consumerChainIdPrefix, l2ChainId)

--- a/itest/opstackl2/op_test_manager.go
+++ b/itest/opstackl2/op_test_manager.go
@@ -396,7 +396,7 @@ func (ctm *OpL2ConsumerTestManager) RegisterBabylonFinalityProvider(t *testing.T
 	return babylonFpPkList
 }
 
-func (ctm *OpL2ConsumerTestManager) WaitForOpchainStuck(t *testing.T) uint64 {
+func (ctm *OpL2ConsumerTestManager) WaitForOpChainStuck(t *testing.T) uint64 {
 	blockHeight := uint64(0)
 	require.Eventually(t, func() bool {
 		finalizedBlock, err := ctm.OpL2ConsumerCtrl.QueryLatestFinalizedBlock()
@@ -408,7 +408,7 @@ func (ctm *OpL2ConsumerTestManager) WaitForOpchainStuck(t *testing.T) uint64 {
 		}
 		blockHeight = latestBlockHeight
 		return false
-	}, e2eutils.EventuallyWaitTimeOut, e2eutils.EventuallyPollTime)
+	}, e2eutils.EventuallyWaitTimeOut, 5*L2BlockTime)
 	return blockHeight
 }
 


### PR DESCRIPTION
This PR adds an op e2e test: 
* close https://github.com/babylonchain/finality-provider/issues/502
* check L2 finality will get stuck if one block didn't get enough votes 
* check L2 finality will recover if the block gets enough votes 

## Test Plan

```
make test-e2e-op
```
