### PR TITLE
consumer: refactor: QueryFinalityProviderVotingPower -> QueryFinalityProviderHasPower

### DIFF
--- a/clientcontroller/api/interface.go
+++ b/clientcontroller/api/interface.go
@@ -44,8 +44,8 @@ type ConsumerController interface {
 
 	// Note: the following queries are only for PoC
 
-	// QueryFinalityProviderVotingPower queries the voting power of the finality provider at a given height
-	QueryFinalityProviderVotingPower(fpPk *btcec.PublicKey, blockHeight uint64) (uint64, error)
+	// QueryFinalityProviderHasPower queries whether the finality provider has voting power at a given height
+	QueryFinalityProviderHasPower(fpPk *btcec.PublicKey, blockHeight uint64) (bool, error)
 
 	// QueryLatestFinalizedBlock returns the latest finalized block
 	// Note: nil will be returned if the finalized block does not exist

--- a/clientcontroller/babylon/babylon.go
+++ b/clientcontroller/babylon/babylon.go
@@ -158,17 +158,17 @@ func (bc *BabylonController) QueryFinalityProviderSlashed(fpPk *btcec.PublicKey)
 	return slashed, nil
 }
 
-// QueryFinalityProviderVotingPower queries the voting power of the finality provider at a given height
-func (bc *BabylonController) QueryFinalityProviderVotingPower(fpPk *btcec.PublicKey, blockHeight uint64) (uint64, error) {
+// QueryFinalityProviderHasPower queries whether the finality provider has voting power at a given height
+func (bc *BabylonController) QueryFinalityProviderHasPower(fpPk *btcec.PublicKey, blockHeight uint64) (bool, error) {
 	res, err := bc.bbnClient.QueryClient.FinalityProviderPowerAtHeight(
 		bbntypes.NewBIP340PubKeyFromBTCPK(fpPk).MarshalHex(),
 		blockHeight,
 	)
 	if err != nil {
-		return 0, fmt.Errorf("failed to query BTC delegations: %w", err)
+		return false, fmt.Errorf("failed to query BTC delegations: %w", err)
 	}
 
-	return res.VotingPower, nil
+	return res.VotingPower > 0, nil
 }
 
 func (bc *BabylonController) QueryLatestFinalizedBlocks(count uint64) ([]*types.BlockInfo, error) {

--- a/clientcontroller/babylon/consumer.go
+++ b/clientcontroller/babylon/consumer.go
@@ -215,17 +215,20 @@ func (bc *BabylonConsumerController) SubmitBatchFinalitySigs(
 	return &types.TxResponse{TxHash: res.TxHash}, nil
 }
 
-// QueryFinalityProviderVotingPower queries the voting power of the finality provider at a given height
-func (bc *BabylonConsumerController) QueryFinalityProviderVotingPower(fpPk *btcec.PublicKey, blockHeight uint64) (uint64, error) {
+// QueryFinalityProviderHasPower queries whether the finality provider has voting power at a given height
+func (bc *BabylonConsumerController) QueryFinalityProviderHasPower(
+	fpPk *btcec.PublicKey,
+	blockHeight uint64,
+) (bool, error) {
 	res, err := bc.bbnClient.QueryClient.FinalityProviderPowerAtHeight(
 		bbntypes.NewBIP340PubKeyFromBTCPK(fpPk).MarshalHex(),
 		blockHeight,
 	)
 	if err != nil {
-		return 0, fmt.Errorf("failed to query the finality provider's voting power at height %d: %w", blockHeight, err)
+		return false, fmt.Errorf("failed to query the finality provider's voting power at height %d: %w", blockHeight, err)
 	}
 
-	return res.VotingPower, nil
+	return res.VotingPower > 0, nil
 }
 
 func (bc *BabylonConsumerController) QueryLatestFinalizedBlock() (*types.BlockInfo, error) {

--- a/clientcontroller/opstackl2/consumer.go
+++ b/clientcontroller/opstackl2/consumer.go
@@ -241,12 +241,12 @@ func (cc *OPStackL2ConsumerController) SubmitBatchFinalitySigs(
 	return &types.TxResponse{TxHash: res.TxHash}, nil
 }
 
-// QueryFinalityProviderVotingPower queries the voting power of the finality provider at a given height.
+// QueryFinalityProviderHasPower queries whether the finality provider has voting power at a given height
 // This interface function only used for checking if the FP is eligible for submitting sigs.
-// Now we can simply hardcode the voting power to a positive value.
+// Now we can simply hardcode the voting power to true
 // TODO: see this issue https://github.com/babylonchain/finality-provider/issues/390 for more details
-func (cc *OPStackL2ConsumerController) QueryFinalityProviderVotingPower(fpPk *btcec.PublicKey, blockHeight uint64) (uint64, error) {
-	return 1, nil
+func (cc *OPStackL2ConsumerController) QueryFinalityProviderHasPower(fpPk *btcec.PublicKey, blockHeight uint64) (bool, error) {
+	return true, nil
 }
 
 // QueryLatestFinalizedBlock returns the finalized L2 block from a RPC call

--- a/finality-provider/service/app.go
+++ b/finality-provider/service/app.go
@@ -257,20 +257,20 @@ func (app *FinalityProviderApp) SyncFinalityProviderStatus() error {
 	}
 
 	for _, fp := range fps {
-		vp, err := app.consumerCon.QueryFinalityProviderVotingPower(fp.BtcPk, latestBlockHeight)
+		hasPower, err := app.consumerCon.QueryFinalityProviderHasPower(fp.BtcPk, latestBlockHeight)
 		if err != nil {
 			// if error occured then the finality-provider is not registered in the Babylon chain yet
 			continue
 		}
 
-		if vp > 0 {
-			// voting power > 0 then set the status to ACTIVE
+		if hasPower {
+			// set the status to ACTIVE
 			err = app.fps.SetFpStatus(fp.BtcPk, proto.FinalityProviderStatus_ACTIVE)
 			if err != nil {
 				return err
 			}
-		} else if vp == 0 {
-			// voting power == 0 then set status depending on previous status
+		} else {
+			// set status depending on previous status
 			switch fp.Status {
 			case proto.FinalityProviderStatus_CREATED:
 				// previous status is CREATED then set to REGISTERED

--- a/finality-provider/service/app_test.go
+++ b/finality-provider/service/app_test.go
@@ -50,8 +50,8 @@ func FuzzRegisterFinalityProvider(f *testing.F) {
 		currentHeight := randomStartingHeight + uint64(r.Int63n(10)+2)
 		mockConsumerController := testutil.PrepareMockedConsumerController(t, r, randomStartingHeight, currentHeight)
 		mockConsumerController.EXPECT().QueryLatestFinalizedBlock().Return(nil, nil).AnyTimes()
-		mockConsumerController.EXPECT().QueryFinalityProviderVotingPower(gomock.Any(),
-			gomock.Any()).Return(uint64(0), nil).AnyTimes()
+		mockConsumerController.EXPECT().QueryFinalityProviderHasPower(gomock.Any(),
+			gomock.Any()).Return(false, nil).AnyTimes()
 		mockBabylonController := testutil.PrepareMockedBabylonController(t)
 
 		// Create randomized config

--- a/finality-provider/service/fastsync_test.go
+++ b/finality-provider/service/fastsync_test.go
@@ -35,8 +35,8 @@ func FuzzFastSync_SufficientRandomness(f *testing.F) {
 		_, err := fpIns.CommitPubRand(randomStartingHeight)
 		require.NoError(t, err)
 
-		mockConsumerController.EXPECT().QueryFinalityProviderVotingPower(fpIns.GetBtcPk(), gomock.Any()).
-			Return(uint64(1), nil).AnyTimes()
+		mockConsumerController.EXPECT().QueryFinalityProviderHasPower(fpIns.GetBtcPk(), gomock.Any()).
+			Return(true, nil).AnyTimes()
 		// the last committed height is higher than the current height
 		// to make sure the randomness is sufficient
 		lastCommittedHeight := randomStartingHeight + testutil.TestPubRandNum
@@ -87,8 +87,8 @@ func FuzzFastSync_NoRandomness(f *testing.F) {
 		_, err := fpIns.CommitPubRand(randomStartingHeight)
 		require.NoError(t, err)
 
-		mockConsumerController.EXPECT().QueryFinalityProviderVotingPower(fpIns.GetBtcPk(), gomock.Any()).
-			Return(uint64(1), nil).AnyTimes()
+		mockConsumerController.EXPECT().QueryFinalityProviderHasPower(fpIns.GetBtcPk(), gomock.Any()).
+			Return(true, nil).AnyTimes()
 		// the last height with pub rand is a random value inside [finalizedHeight+1, currentHeight]
 		lastHeightWithPubRand := uint64(rand.Intn(int(currentHeight)-int(finalizedHeight))) + finalizedHeight + 1
 		lastCommittedPubRand := &types.PubRandCommit{

--- a/finality-provider/service/fp_instance_test.go
+++ b/finality-provider/service/fp_instance_test.go
@@ -33,8 +33,8 @@ func FuzzCommitPubRandList(f *testing.F) {
 		expectedTxHash := testutil.GenRandomHexStr(r, 32)
 		mockBabylonController := testutil.PrepareMockedBabylonController(t)
 		mockConsumerController := testutil.PrepareMockedConsumerControllerWithTxHash(t, r, randomStartingHeight, currentHeight, expectedTxHash)
-		mockConsumerController.EXPECT().QueryFinalityProviderVotingPower(gomock.Any(), gomock.Any()).
-			Return(uint64(0), nil).AnyTimes()
+		mockConsumerController.EXPECT().QueryFinalityProviderHasPower(gomock.Any(), gomock.Any()).
+			Return(false, nil).AnyTimes()
 		_, fpIns, cleanUp := startFinalityProviderAppWithRegisteredFp(t, r, mockBabylonController, mockConsumerController, randomStartingHeight)
 		defer cleanUp()
 
@@ -77,8 +77,8 @@ func FuzzSubmitFinalitySig(f *testing.F) {
 		}
 		mockConsumerController.EXPECT().QueryLastPublicRandCommit(gomock.Any()).Return(lastCommittedPubRand, nil).AnyTimes()
 		// mock voting power and commit pub rand
-		mockConsumerController.EXPECT().QueryFinalityProviderVotingPower(fpIns.GetBtcPk(), gomock.Any()).
-			Return(uint64(1), nil).AnyTimes()
+		mockConsumerController.EXPECT().QueryFinalityProviderHasPower(fpIns.GetBtcPk(), gomock.Any()).
+			Return(true, nil).AnyTimes()
 
 		// submit finality sig
 		nextBlock := &types.BlockInfo{

--- a/itest/opstackl2/op_e2e_test.go
+++ b/itest/opstackl2/op_e2e_test.go
@@ -41,7 +41,7 @@ func TestOpSubmitFinalitySignature(t *testing.T) {
 		BlockTimestamp: 12345, // doesn't matter b/c the BTC client is mocked
 	}
 
-	// note: QueryFinalityProviderVotingPower is hardcode to return 1 so FPs can still submit finality sigs even if they
+	// note: QueryFinalityProviderHasPower is hardcode to return true so FPs can still submit finality sigs even if they
 	// don't have voting power. But the finality sigs will not be counted at tally time.
 	_, err = ctm.SdkClient.QueryIsBlockBabylonFinalized(queryParams)
 	require.ErrorIs(t, err, sdk.ErrNoFpHasVotingPower)

--- a/testutil/mocks/clientcontroller.go
+++ b/testutil/mocks/clientcontroller.go
@@ -178,19 +178,19 @@ func (mr *MockConsumerControllerMockRecorder) QueryBlocks(startHeight, endHeight
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryBlocks", reflect.TypeOf((*MockConsumerController)(nil).QueryBlocks), startHeight, endHeight, limit)
 }
 
-// QueryFinalityProviderVotingPower mocks base method.
-func (m *MockConsumerController) QueryFinalityProviderVotingPower(fpPk *btcec.PublicKey, blockHeight uint64) (uint64, error) {
+// QueryFinalityProviderHasPower mocks base method.
+func (m *MockConsumerController) QueryFinalityProviderHasPower(fpPk *btcec.PublicKey, blockHeight uint64) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "QueryFinalityProviderVotingPower", fpPk, blockHeight)
-	ret0, _ := ret[0].(uint64)
+	ret := m.ctrl.Call(m, "QueryFinalityProviderHasPower", fpPk, blockHeight)
+	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// QueryFinalityProviderVotingPower indicates an expected call of QueryFinalityProviderVotingPower.
-func (mr *MockConsumerControllerMockRecorder) QueryFinalityProviderVotingPower(fpPk, blockHeight interface{}) *gomock.Call {
+// QueryFinalityProviderHasPower indicates an expected call of QueryFinalityProviderHasPower.
+func (mr *MockConsumerControllerMockRecorder) QueryFinalityProviderHasPower(fpPk, blockHeight interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryFinalityProviderVotingPower", reflect.TypeOf((*MockConsumerController)(nil).QueryFinalityProviderVotingPower), fpPk, blockHeight)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryFinalityProviderHasPower", reflect.TypeOf((*MockConsumerController)(nil).QueryFinalityProviderHasPower), fpPk, blockHeight)
 }
 
 // QueryIsBlockFinalized mocks base method.


### PR DESCRIPTION
## Summary

context in https://github.com/babylonchain/finality-provider/issues/496

this interface function is only used for checking if the FP is eligible for submitting sigs

per @SebastianElvis's suggestion, instead of querying the exact voting power, the FP queries BTC delegations page by page, and if there is >=1 active BTC delegation, then it can vote.

this PR first tightens the interface

next, I will work on the implementation per algorithm ^

## Test Plan

```
make mock-gen
make lint
make test-e2e-babylon 
```