### PR TITLE
consumer: fix: data race in cosmwasmclient/client/client.go

### DIFF
--- a/cosmwasmclient/client/client.go
+++ b/cosmwasmclient/client/client.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	wasmdparams "github.com/CosmWasm/wasmd/app/params"
@@ -13,6 +14,7 @@ import (
 )
 
 type Client struct {
+	mu sync.Mutex
 	*query.QueryClient
 
 	provider *cosmos.CosmosProvider
@@ -83,11 +85,11 @@ func New(cfg *config.CosmwasmConfig, chainName string, encodingCfg wasmdparams.E
 	}
 
 	return &Client{
-		queryClient,
-		cp,
-		cfg.Timeout,
-		zapLogger,
-		cfg,
+		QueryClient: queryClient,
+		provider:    cp,
+		timeout:     cfg.Timeout,
+		logger:      zapLogger,
+		cfg:         cfg,
 	}, nil
 }
 

--- a/cosmwasmclient/client/tx.go
+++ b/cosmwasmclient/client/tx.go
@@ -31,6 +31,9 @@ func (c *Client) SendMsgToMempool(ctx context.Context, msg sdk.Msg) error {
 // SendMsgsToMempool sends a set of messages to the mempool.
 // It does not wait for the messages to be included.
 func (c *Client) SendMsgsToMempool(ctx context.Context, msgs []sdk.Msg) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	relayerMsgs := ToProviderMsgs(msgs)
 	if err := retry.Do(func() error {
 		var sendMsgErr error
@@ -62,6 +65,9 @@ func (c *Client) ReliablySendMsg(ctx context.Context, msg sdk.Msg, expectedError
 // It utilizes a file lock as well as a keyring lock to ensure atomic access.
 // TODO: needs tests
 func (c *Client) ReliablySendMsgs(ctx context.Context, msgs []sdk.Msg, expectedErrors []*errors.Error, unrecoverableErrors []*errors.Error) (*pv.RelayerTxResponse, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	var (
 		rlyResp     *pv.RelayerTxResponse
 		callbackErr error


### PR DESCRIPTION
## Summary

fixing another data race.

it's caused by fast sync and the main sig submission loop calling `ReliablySendMsgs` function from the  same `cc.CwClient`

context: https://github.com/babylonchain/finality-provider/issues/478

## Test Plan
first add `-race` in the make file command then run `make test-e2e-op`

before this PR I see:

<details><summary> data race messages</summary>

```
==================
WARNING: DATA RACE
Write at 0x00c0089a9330 by goroutine 355805:
  cosmossdk.io/x/tx/signing.(*Context).makeGetSignersFunc.func5()
      /Users/zidong/go/pkg/mod/cosmossdk.io/x/tx@v0.13.3/signing/context.go:311 +0xdc
  cosmossdk.io/x/tx/signing.(*Context).GetSigners()
      /Users/zidong/go/pkg/mod/cosmossdk.io/x/tx@v0.13.3/signing/context.go:357 +0x98
  github.com/cosmos/cosmos-sdk/codec.ProtoCodec.GetMsgAnySigners()
      /Users/zidong/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.50.6/codec/proto_codec.go:311 +0x188
  github.com/cosmos/cosmos-sdk/codec.(*ProtoCodec).GetMsgV1Signers()
      /Users/zidong/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.50.6/codec/proto_codec.go:328 +0xc0
  github.com/cosmos/relayer/v2/relayer/chains/cosmos.getFeePayer()
      /Users/zidong/go/pkg/mod/github.com/cosmos/relayer/v2@v2.5.2/relayer/chains/cosmos/log.go:182 +0x350
  github.com/cosmos/relayer/v2/relayer/chains/cosmos.(*CosmosProvider).LogSuccessTx()
      /Users/zidong/go/pkg/mod/github.com/cosmos/relayer/v2@v2.5.2/relayer/chains/cosmos/log.go:110 +0x67c
  github.com/cosmos/relayer/v2/relayer/chains/cosmos.(*CosmosProvider).waitForTx()
      /Users/zidong/go/pkg/mod/github.com/cosmos/relayer/v2@v2.5.2/relayer/chains/cosmos/tx.go:458 +0x580
  github.com/cosmos/relayer/v2/relayer/chains/cosmos.(*CosmosProvider).broadcastTx.gowrap1()
      /Users/zidong/go/pkg/mod/github.com/cosmos/relayer/v2@v2.5.2/relayer/chains/cosmos/tx.go:397 +0xc8

Previous read at 0x00c0089a9330 by goroutine 357686:
  cosmossdk.io/x/tx/signing.(*Context).makeGetSignersFunc.func5()
      /Users/zidong/go/pkg/mod/cosmossdk.io/x/tx@v0.13.3/signing/context.go:312 +0x118
  cosmossdk.io/x/tx/signing.(*Context).GetSigners()
      /Users/zidong/go/pkg/mod/cosmossdk.io/x/tx@v0.13.3/signing/context.go:357 +0x98
  github.com/cosmos/cosmos-sdk/codec.ProtoCodec.GetMsgAnySigners()
      /Users/zidong/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.50.6/codec/proto_codec.go:311 +0x188
  github.com/cosmos/cosmos-sdk/codec.(*ProtoCodec).GetMsgV1Signers()
      /Users/zidong/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.50.6/codec/proto_codec.go:328 +0xc0
  github.com/cosmos/relayer/v2/relayer/chains/cosmos.getFeePayer()
      /Users/zidong/go/pkg/mod/github.com/cosmos/relayer/v2@v2.5.2/relayer/chains/cosmos/log.go:182 +0x350
  github.com/cosmos/relayer/v2/relayer/chains/cosmos.(*CosmosProvider).LogSuccessTx()
      /Users/zidong/go/pkg/mod/github.com/cosmos/relayer/v2@v2.5.2/relayer/chains/cosmos/log.go:110 +0x67c
  github.com/cosmos/relayer/v2/relayer/chains/cosmos.(*CosmosProvider).waitForTx()
      /Users/zidong/go/pkg/mod/github.com/cosmos/relayer/v2@v2.5.2/relayer/chains/cosmos/tx.go:458 +0x580
  github.com/cosmos/relayer/v2/relayer/chains/cosmos.(*CosmosProvider).broadcastTx.gowrap1()
      /Users/zidong/go/pkg/mod/github.com/cosmos/relayer/v2@v2.5.2/relayer/chains/cosmos/tx.go:397 +0xc8

Goroutine 355805 (running) created at:
  github.com/cosmos/relayer/v2/relayer/chains/cosmos.(*CosmosProvider).broadcastTx()
      /Users/zidong/go/pkg/mod/github.com/cosmos/relayer/v2@v2.5.2/relayer/chains/cosmos/tx.go:397 +0x6d4
  github.com/cosmos/relayer/v2/relayer/chains/cosmos.(*CosmosProvider).SendMessagesToMempool()
      /Users/zidong/go/pkg/mod/github.com/cosmos/relayer/v2@v2.5.2/relayer/chains/cosmos/tx.go:185 +0x274
  github.com/babylonchain/finality-provider/cosmwasmclient/client.(*Client).ReliablySendMsgs.func2.1()
      /Users/zidong/Documents/Projects/babylon-finality-provider/cosmwasmclient/client/tx.go:86 +0xf4
  github.com/babylonchain/finality-provider/cosmwasmclient/client.(*Client).accessKeyWithLock()
      /Users/zidong/Documents/Projects/babylon-finality-provider/cosmwasmclient/client/keys.go:41 +0x1b8
  github.com/babylonchain/finality-provider/cosmwasmclient/client.(*Client).ReliablySendMsgs.func2()
      /Users/zidong/Documents/Projects/babylon-finality-provider/cosmwasmclient/client/tx.go:85 +0x148
  github.com/avast/retry-go/v4.Do.func1()
      /Users/zidong/go/pkg/mod/github.com/avast/retry-go/v4@v4.5.1/retry.go:115 +0x30
  github.com/avast/retry-go/v4.DoWithData[go.shape.interface {}]()
      /Users/zidong/go/pkg/mod/github.com/avast/retry-go/v4@v4.5.1/retry.go:179 +0x8f8
  github.com/avast/retry-go/v4.Do()
      /Users/zidong/go/pkg/mod/github.com/avast/retry-go/v4@v4.5.1/retry.go:118 +0x70
  github.com/babylonchain/finality-provider/cosmwasmclient/client.(*Client).ReliablySendMsgs()
      /Users/zidong/Documents/Projects/babylon-finality-provider/cosmwasmclient/client/tx.go:83 +0x58c
  github.com/babylonchain/finality-provider/clientcontroller/opstackl2.(*OPStackL2ConsumerController).reliablySendMsgs()
      /Users/zidong/Documents/Projects/babylon-finality-provider/clientcontroller/opstackl2/consumer.go:103 +0x6c4
  github.com/babylonchain/finality-provider/clientcontroller/opstackl2.(*OPStackL2ConsumerController).SubmitBatchFinalitySigs()
      /Users/zidong/Documents/Projects/babylon-finality-provider/clientcontroller/opstackl2/consumer.go:232 +0x680
  github.com/babylonchain/finality-provider/finality-provider/service.(*FinalityProviderInstance).SubmitBatchFinalitySignatures()
      /Users/zidong/Documents/Projects/babylon-finality-provider/finality-provider/service/fp_instance.go:858 +0x424
  github.com/babylonchain/finality-provider/finality-provider/service.(*FinalityProviderInstance).FastSync()
      /Users/zidong/Documents/Projects/babylon-finality-provider/finality-provider/service/fastsync.go:83 +0x3ac
  github.com/babylonchain/finality-provider/finality-provider/service.(*FinalityProviderInstance).tryFastSync()
      /Users/zidong/Documents/Projects/babylon-finality-provider/finality-provider/service/fp_instance.go:431 +0x1a4
  github.com/babylonchain/finality-provider/finality-provider/service.(*FinalityProviderInstance).finalitySigSubmissionLoop()
      /Users/zidong/Documents/Projects/babylon-finality-provider/finality-provider/service/fp_instance.go:248 +0x194
  github.com/babylonchain/finality-provider/finality-provider/service.(*FinalityProviderInstance).Start.gowrap1()
      /Users/zidong/Documents/Projects/babylon-finality-provider/finality-provider/service/fp_instance.go:134 +0x34

Goroutine 357686 (finished) created at:
  github.com/cosmos/relayer/v2/relayer/chains/cosmos.(*CosmosProvider).broadcastTx()
      /Users/zidong/go/pkg/mod/github.com/cosmos/relayer/v2@v2.5.2/relayer/chains/cosmos/tx.go:397 +0x6d4
  github.com/cosmos/relayer/v2/relayer/chains/cosmos.(*CosmosProvider).SendMessagesToMempool()
      /Users/zidong/go/pkg/mod/github.com/cosmos/relayer/v2@v2.5.2/relayer/chains/cosmos/tx.go:185 +0x274
  github.com/babylonchain/finality-provider/cosmwasmclient/client.(*Client).ReliablySendMsgs.func2.1()
      /Users/zidong/Documents/Projects/babylon-finality-provider/cosmwasmclient/client/tx.go:86 +0xf4
  github.com/babylonchain/finality-provider/cosmwasmclient/client.(*Client).accessKeyWithLock()
      /Users/zidong/Documents/Projects/babylon-finality-provider/cosmwasmclient/client/keys.go:41 +0x1b8
  github.com/babylonchain/finality-provider/cosmwasmclient/client.(*Client).ReliablySendMsgs.func2()
      /Users/zidong/Documents/Projects/babylon-finality-provider/cosmwasmclient/client/tx.go:85 +0x148
  github.com/avast/retry-go/v4.Do.func1()
      /Users/zidong/go/pkg/mod/github.com/avast/retry-go/v4@v4.5.1/retry.go:115 +0x30
  github.com/avast/retry-go/v4.DoWithData[go.shape.interface {}]()
      /Users/zidong/go/pkg/mod/github.com/avast/retry-go/v4@v4.5.1/retry.go:179 +0x8f8
  github.com/avast/retry-go/v4.Do()
      /Users/zidong/go/pkg/mod/github.com/avast/retry-go/v4@v4.5.1/retry.go:118 +0x70
  github.com/babylonchain/finality-provider/cosmwasmclient/client.(*Client).ReliablySendMsgs()
      /Users/zidong/Documents/Projects/babylon-finality-provider/cosmwasmclient/client/tx.go:83 +0x58c
  github.com/babylonchain/finality-provider/clientcontroller/opstackl2.(*OPStackL2ConsumerController).reliablySendMsgs()
      /Users/zidong/Documents/Projects/babylon-finality-provider/clientcontroller/opstackl2/consumer.go:103 +0xb0
  github.com/babylonchain/finality-provider/clientcontroller/opstackl2.(*OPStackL2ConsumerController).ReliablySendMsg()
      /Users/zidong/Documents/Projects/babylon-finality-provider/clientcontroller/opstackl2/consumer.go:99 +0x1c
  github.com/babylonchain/finality-provider/clientcontroller/opstackl2.(*OPStackL2ConsumerController).CommitPubRandList()
      /Users/zidong/Documents/Projects/babylon-finality-provider/clientcontroller/opstackl2/consumer.go:139 +0x2f0
  github.com/babylonchain/finality-provider/finality-provider/service.(*FinalityProviderInstance).CommitPubRand()
      /Users/zidong/Documents/Projects/babylon-finality-provider/finality-provider/service/fp_instance.go:773 +0x360
  github.com/babylonchain/finality-provider/finality-provider/service.(*FinalityProviderInstance).retryCommitPubRandUntilBlockFinalized()
      /Users/zidong/Documents/Projects/babylon-finality-provider/finality-provider/service/fp_instance.go:632 +0x48
  github.com/babylonchain/finality-provider/finality-provider/service.(*FinalityProviderInstance).randomnessCommitmentLoop()
      /Users/zidong/Documents/Projects/babylon-finality-provider/finality-provider/service/fp_instance.go:331 +0x8b0
  github.com/babylonchain/finality-provider/finality-provider/service.(*FinalityProviderInstance).Start.gowrap2()
      /Users/zidong/Documents/Projects/babylon-finality-provider/finality-provider/service/fp_instance.go:136 +0x40
==================
```

</details>

after this PR, I don't see anything and test can pass