### PR TITLE
fix: data race in `GetLastProcessedHeight()` and `GetLastVotedHeight()`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ test-e2e-babylon: clean-e2e install-babylond
 	@go test -mod=readonly -timeout=25m -v $(PACKAGES_E2E) -count=1 --tags=e2e_babylon
 
 test-e2e-bcd: clean-e2e install-babylond install-bcd
-	@go test -mod=readonly -timeout=25m -v $(PACKAGES_E2E_BCD) -count=1 --tags=e2e_bcd
+	@go test -race -mod=readonly -timeout=25m -v $(PACKAGES_E2E_BCD) -count=1 --tags=e2e_bcd
 
 test-e2e-wasmd: clean-e2e install-babylond install-wasmd
 	@go test -mod=readonly -timeout=25m -v $(PACKAGES_E2E) -count=1 --tags=e2e_wasmd

--- a/finality-provider/service/fp_store_adapter.go
+++ b/finality-provider/service/fp_store_adapter.go
@@ -60,9 +60,9 @@ type CreateFinalityProviderResult struct {
 }
 
 type fpState struct {
-	mu sync.Mutex
-	fp *store.StoredFinalityProvider
-	s  *store.FinalityProviderStore
+	mu  sync.Mutex
+	sfp *store.StoredFinalityProvider
+	s   *store.FinalityProviderStore
 }
 
 func NewFpState(
@@ -70,49 +70,57 @@ func NewFpState(
 	s *store.FinalityProviderStore,
 ) *fpState {
 	return &fpState{
-		fp: fp,
-		s:  s,
+		sfp: fp,
+		s:   s,
 	}
 }
 
-func (fps *fpState) getStoreFinalityProvider() *store.StoredFinalityProvider {
+func (fps *fpState) withLock(action func()) {
 	fps.mu.Lock()
 	defer fps.mu.Unlock()
-	return fps.fp
+	action()
 }
 
 func (fps *fpState) setStatus(s proto.FinalityProviderStatus) error {
-	fps.mu.Lock()
-	fps.fp.Status = s
-	fps.mu.Unlock()
-	return fps.s.SetFpStatus(fps.fp.BtcPk, s)
+	fps.withLock(func() {
+		fps.sfp.Status = s
+	})
+	return fps.s.SetFpStatus(fps.sfp.BtcPk, s)
 }
 
 func (fps *fpState) setLastProcessedHeight(height uint64) error {
-	fps.mu.Lock()
-	fps.fp.LastProcessedHeight = height
-	fps.mu.Unlock()
-	return fps.s.SetFpLastProcessedHeight(fps.fp.BtcPk, height)
+	fps.withLock(func() {
+		fps.sfp.LastProcessedHeight = height
+	})
+	return fps.s.SetFpLastProcessedHeight(fps.sfp.BtcPk, height)
 }
 
 func (fps *fpState) setLastProcessedAndVotedHeight(height uint64) error {
-	fps.mu.Lock()
-	fps.fp.LastVotedHeight = height
-	fps.fp.LastProcessedHeight = height
-	fps.mu.Unlock()
-	return fps.s.SetFpLastVotedHeight(fps.fp.BtcPk, height)
+	fps.withLock(func() {
+		fps.sfp.LastVotedHeight = height
+		fps.sfp.LastProcessedHeight = height
+	})
+	return fps.s.SetFpLastVotedHeight(fps.sfp.BtcPk, height)
 }
 
 func (fp *FinalityProviderInstance) GetStoreFinalityProvider() *store.StoredFinalityProvider {
-	return fp.fpState.getStoreFinalityProvider()
+	return fp.fpState.sfp
 }
 
 func (fp *FinalityProviderInstance) GetBtcPkBIP340() *bbntypes.BIP340PubKey {
-	return fp.fpState.getStoreFinalityProvider().GetBIP340BTCPK()
+	var pk *bbntypes.BIP340PubKey
+	fp.fpState.withLock(func() {
+		pk = fp.fpState.sfp.GetBIP340BTCPK()
+	})
+	return pk
 }
 
 func (fp *FinalityProviderInstance) GetBtcPk() *btcec.PublicKey {
-	return fp.fpState.getStoreFinalityProvider().BtcPk
+	var pk *btcec.PublicKey
+	fp.fpState.withLock(func() {
+		pk = fp.fpState.sfp.BtcPk
+	})
+	return pk
 }
 
 func (fp *FinalityProviderInstance) GetBtcPkHex() string {
@@ -120,25 +128,35 @@ func (fp *FinalityProviderInstance) GetBtcPkHex() string {
 }
 
 func (fp *FinalityProviderInstance) GetStatus() proto.FinalityProviderStatus {
-	return fp.fpState.getStoreFinalityProvider().Status
+	var status proto.FinalityProviderStatus
+	fp.fpState.withLock(func() {
+		status = fp.fpState.sfp.Status
+	})
+	return status
 }
 
 func (fp *FinalityProviderInstance) GetLastVotedHeight() uint64 {
-	fp.fpState.mu.Lock()
-	lastVotedHeight := fp.fpState.fp.LastVotedHeight
-	fp.fpState.mu.Unlock()
+	var lastVotedHeight uint64
+	fp.fpState.withLock(func() {
+		lastVotedHeight = fp.fpState.sfp.LastVotedHeight
+	})
 	return lastVotedHeight
 }
 
 func (fp *FinalityProviderInstance) GetLastProcessedHeight() uint64 {
-	fp.fpState.mu.Lock()
-	lastProcessedHeight := fp.fpState.fp.LastProcessedHeight
-	fp.fpState.mu.Unlock()
+	var lastProcessedHeight uint64
+	fp.fpState.withLock(func() {
+		lastProcessedHeight = fp.fpState.sfp.LastProcessedHeight
+	})
 	return lastProcessedHeight
 }
 
 func (fp *FinalityProviderInstance) GetChainID() []byte {
-	return []byte(fp.fpState.getStoreFinalityProvider().ChainID)
+	var chainID string
+	fp.fpState.withLock(func() {
+		chainID = fp.fpState.sfp.ChainID
+	})
+	return []byte(chainID)
 }
 
 func (fp *FinalityProviderInstance) SetStatus(s proto.FinalityProviderStatus) error {

--- a/finality-provider/service/fp_store_adapter.go
+++ b/finality-provider/service/fp_store_adapter.go
@@ -124,11 +124,17 @@ func (fp *FinalityProviderInstance) GetStatus() proto.FinalityProviderStatus {
 }
 
 func (fp *FinalityProviderInstance) GetLastVotedHeight() uint64 {
-	return fp.fpState.getStoreFinalityProvider().LastVotedHeight
+	fp.fpState.mu.Lock()
+	lastVotedHeight := fp.fpState.fp.LastVotedHeight
+	fp.fpState.mu.Unlock()
+	return lastVotedHeight
 }
 
 func (fp *FinalityProviderInstance) GetLastProcessedHeight() uint64 {
-	return fp.fpState.getStoreFinalityProvider().LastProcessedHeight
+	fp.fpState.mu.Lock()
+	lastProcessedHeight := fp.fpState.fp.LastProcessedHeight
+	fp.fpState.mu.Unlock()
+	return lastProcessedHeight
 }
 
 func (fp *FinalityProviderInstance) GetChainID() []byte {

--- a/itest/opstackl2/op_e2e_test.go
+++ b/itest/opstackl2/op_e2e_test.go
@@ -119,7 +119,7 @@ func TestOpMultipleFinalityProviders(t *testing.T) {
 	log.Logf(t, "Stopped the first FP instance")
 
 	// select a block that the first FP has not processed yet to give to the second FP to sign
-	testNextBlockHeight := fpList[0].GetLastProcessedHeight() + 1
+	testNextBlockHeight := fpList[0].GetLastVotedHeight() + 1
 	log.Logf(t, "Test next block height %d", testNextBlockHeight)
 	ctm.WaitForFpVoteAtHeight(t, fpList[1], testNextBlockHeight)
 


### PR DESCRIPTION
## Summary

This PR fixes the data race in these two functions using the `sync.Mutex`

* `GetLastProcessedHeight()` to fix the data race when running the bcd e2e test, below are the data race details
  <details>
  <summary> data race </summary>
  
  ```
  ==================
  WARNING: DATA RACE
  Write at 0x00c000c7a290 by goroutine 400:
    github.com/babylonchain/finality-provider/finality-provider/service.(*fpState).setLastProcessedAndVotedHeight()
        /Users/lyy/babylon/finality-provider/finality-provider/service/fp_store_adapter.go:101 +0x8c
    github.com/babylonchain/finality-provider/finality-provider/service.(*FinalityProviderInstance).updateStateAfterFinalitySigSubmission()
        /Users/lyy/babylon/finality-provider/finality-provider/service/fp_store_adapter.go:162 +0x48
    github.com/babylonchain/finality-provider/finality-provider/service.(*FinalityProviderInstance).MustUpdateStateAfterFinalitySigSubmission()
        /Users/lyy/babylon/finality-provider/finality-provider/service/fp_store_adapter.go:166 +0x4c
    github.com/babylonchain/finality-provider/finality-provider/service.(*FinalityProviderInstance).SubmitFinalitySignature()
        /Users/lyy/babylon/finality-provider/finality-provider/service/fp_instance.go:819 +0x44c
    github.com/babylonchain/finality-provider/finality-provider/service.(*FinalityProviderInstance).retrySubmitFinalitySignatureUntilBlockFinalized()
        /Users/lyy/babylon/finality-provider/finality-provider/service/fp_instance.go:565 +0x48
    github.com/babylonchain/finality-provider/finality-provider/service.(*FinalityProviderInstance).finalitySigSubmissionLoop()
        /Users/lyy/babylon/finality-provider/finality-provider/service/fp_instance.go:227 +0xd18
    github.com/babylonchain/finality-provider/finality-provider/service.(*FinalityProviderInstance).Start.func1()
        /Users/lyy/babylon/finality-provider/finality-provider/service/fp_instance.go:134 +0x34
  
  Previous read at 0x00c000c7a290 by goroutine 402:
    github.com/babylonchain/finality-provider/finality-provider/service.(*FinalityProviderInstance).GetLastProcessedHeight()
        /Users/lyy/babylon/finality-provider/finality-provider/service/fp_store_adapter.go:131 +0x43c
    github.com/babylonchain/finality-provider/finality-provider/service.(*FinalityProviderInstance).checkLagging()
        /Users/lyy/babylon/finality-provider/finality-provider/service/fp_instance.go:494 +0x44c
    github.com/babylonchain/finality-provider/finality-provider/service.(*FinalityProviderInstance).checkLaggingLoop()
        /Users/lyy/babylon/finality-provider/finality-provider/service/fp_instance.go:383 +0x484
    github.com/babylonchain/finality-provider/finality-provider/service.(*FinalityProviderInstance).Start.func3()
        /Users/lyy/babylon/finality-provider/finality-provider/service/fp_instance.go:138 +0x34
  
  Goroutine 400 (running) created at:
    github.com/babylonchain/finality-provider/finality-provider/service.(*FinalityProviderInstance).Start()
        /Users/lyy/babylon/finality-provider/finality-provider/service/fp_instance.go:134 +0x5c8
    github.com/babylonchain/finality-provider/finality-provider/service.(*FinalityProviderManager).addFinalityProviderInstance()
        /Users/lyy/babylon/finality-provider/finality-provider/service/fp_manager.go:415 +0x2b0
    github.com/babylonchain/finality-provider/finality-provider/service.(*FinalityProviderManager).StartFinalityProvider()
        /Users/lyy/babylon/finality-provider/finality-provider/service/fp_manager.go:226 +0x1b8
    github.com/babylonchain/finality-provider/finality-provider/service.(*FinalityProviderApp).StartHandlingFinalityProvider()
        /Users/lyy/babylon/finality-provider/finality-provider/service/app.go:230 +0x16ac
    github.com/babylonchain/finality-provider/itest/cosmwasm/bcd.TestConsumerFpLifecycle()
        /Users/lyy/babylon/finality-provider/itest/cosmwasm/bcd/bcd_consumer_e2e_test.go:119 +0x1664
    testing.tRunner()
        /usr/local/go/src/testing/testing.go:1595 +0x1b0
    testing.(*T).Run.func1()
        /usr/local/go/src/testing/testing.go:1648 +0x40
  
  Goroutine 402 (running) created at:
    github.com/babylonchain/finality-provider/finality-provider/service.(*FinalityProviderInstance).Start()
        /Users/lyy/babylon/finality-provider/finality-provider/service/fp_instance.go:138 +0x6bc
    github.com/babylonchain/finality-provider/finality-provider/service.(*FinalityProviderManager).addFinalityProviderInstance()
        /Users/lyy/babylon/finality-provider/finality-provider/service/fp_manager.go:415 +0x2b0
    github.com/babylonchain/finality-provider/finality-provider/service.(*FinalityProviderManager).StartFinalityProvider()
        /Users/lyy/babylon/finality-provider/finality-provider/service/fp_manager.go:226 +0x1b8
    github.com/babylonchain/finality-provider/finality-provider/service.(*FinalityProviderApp).StartHandlingFinalityProvider()
        /Users/lyy/babylon/finality-provider/finality-provider/service/app.go:230 +0x16ac
    github.com/babylonchain/finality-provider/itest/cosmwasm/bcd.TestConsumerFpLifecycle()
        /Users/lyy/babylon/finality-provider/itest/cosmwasm/bcd/bcd_consumer_e2e_test.go:119 +0x1664
    testing.tRunner()
        /usr/local/go/src/testing/testing.go:1595 +0x1b0
    testing.(*T).Run.func1()
        /usr/local/go/src/testing/testing.go:1648 +0x40
  ==================
  
      testing.go:1465: race detected during execution of test
  --- FAIL: TestConsumerFpLifecycle (99.93s)
  === NAME
      testing.go:1465: race detected during execution of test
  FAIL
  FAIL	github.com/babylonchain/finality-provider/itest/cosmwasm/bcd	101.861s
  FAIL
  make: *** [test-e2e-bcd] Error 1
  ```
  
  </details>

* `GetLastVotedHeight()` to fix the data race mentioned by this comment https://github.com/babylonchain/finality-provider/pull/506#issuecomment-2221898354

Also, let us discuss how to handle this kind of data race, and whether it is a proper way, if yes, we can update other functions in this way.

## Test Plan

```
make test-e2e-bcd
```