### PR TITLE
feat: add validate-signed-finality-provider command

### DIFF
--- a/finality-provider/cmd/fpd/daemon/flags.go
+++ b/finality-provider/cmd/fpd/daemon/flags.go
@@ -11,6 +11,7 @@ const (
 	hdPathFlag           = "hd-path"
 	chainIdFlag          = "chain-id"
 	signedFlag           = "signed"
+	btcNetworkFlag       = "network"
 
 	// flags for description
 	monikerFlag         = "moniker"

--- a/finality-provider/cmd/fpd/daemon/flags.go
+++ b/finality-provider/cmd/fpd/daemon/flags.go
@@ -11,7 +11,6 @@ const (
 	hdPathFlag           = "hd-path"
 	chainIdFlag          = "chain-id"
 	signedFlag           = "signed"
-	btcNetworkFlag       = "network"
 
 	// flags for description
 	monikerFlag         = "moniker"

--- a/finality-provider/cmd/fpd/daemon/tx.go
+++ b/finality-provider/cmd/fpd/daemon/tx.go
@@ -1,10 +1,18 @@
 package daemon
 
 import (
+	"fmt"
+	"strings"
+
+	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/spf13/cobra"
 
 	btcstakingcli "github.com/babylonchain/babylon/x/btcstaking/client/cli"
+	btcstakingtypes "github.com/babylonchain/babylon/x/btcstaking/types"
+	fpcfg "github.com/babylonchain/finality-provider/finality-provider/config"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authclient "github.com/cosmos/cosmos-sdk/x/auth/client"
 	authcli "github.com/cosmos/cosmos-sdk/x/auth/client/cli"
 )
 
@@ -21,7 +29,103 @@ func CommandTxs() *cobra.Command {
 	cmd.AddCommand(
 		authcli.GetSignCommand(),
 		btcstakingcli.NewCreateFinalityProviderCmd(),
+		NewValidateSignedFinalityProviderCmd(),
 	)
+
+	return cmd
+}
+
+// NewValidateSignedFinalityProviderCmd returns the command line for
+// tx validate-signed-finality-provider
+func NewValidateSignedFinalityProviderCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "validate-signed-finality-provider [file_path_signed_msg]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Validates if the signed finality provider is valid",
+		Long: strings.TrimSpace(`
+			Loads the signed msg MsgCreateFinalityProvider and checks if the basic
+			information is satisfied and the Proof of Possession is in valid by the
+			signer of the msg and the finality provider address
+		`),
+		Example: strings.TrimSpace(
+			`fdp tx validate-signed-finality-provider ./path/to/signed-msg.json`,
+		),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			networkBTC, err := cmd.Flags().GetString(btcNetworkFlag)
+			if err != nil {
+				return err
+			}
+
+			var btcNetCfg chaincfg.Params
+			if len(networkBTC) == 0 { // not set in flag, load from config
+				cfg, err := fpcfg.LoadConfig(ctx.HomeDir)
+				if err != nil {
+					return fmt.Errorf("failed to load configuration at %s: %w", ctx.HomeDir, err)
+				}
+				btcNetCfg = cfg.BTCNetParams
+			} else {
+				btcNetCfg, err = fpcfg.NetParamsBTC(networkBTC)
+				if err != nil {
+					return err
+				}
+			}
+
+			stdTx, err := authclient.ReadTxFromFile(ctx, args[0])
+			if err != nil {
+				return err
+			}
+
+			msgsV2, err := stdTx.GetMsgsV2()
+			if err != nil {
+				return err
+			}
+
+			msgs := stdTx.GetMsgs()
+			for i, sdkMsg := range msgs {
+				msgV2 := msgsV2[i]
+				msg, ok := sdkMsg.(*btcstakingtypes.MsgCreateFinalityProvider)
+				if !ok {
+					return fmt.Errorf("unable to parse %+v to MsgCreateFinalityProvider", msg)
+				}
+
+				if err := msg.ValidateBasic(); err != nil {
+					return fmt.Errorf("error validating basic msg: %w", err)
+				}
+
+				signers, err := ctx.Codec.GetMsgV2Signers(msgV2)
+				if err != nil {
+					return fmt.Errorf("error %w failed to get signers from msg: %+v", err, msg)
+				}
+
+				if len(signers) == 0 {
+					return fmt.Errorf("no signer at msg %+v", msgV2)
+				}
+
+				addrStr, err := ctx.Codec.InterfaceRegistry().SigningContext().AddressCodec().BytesToString(signers[0])
+				if err != nil {
+					return err
+				}
+
+				bbnAddr, err := sdk.AccAddressFromBech32(addrStr)
+				if err != nil {
+					return fmt.Errorf("invalid signer address %s, please sign with a valid bbn address, err: %w", addrStr, err)
+				}
+
+				if err := msg.Pop.Verify(bbnAddr, msg.BtcPk, &btcNetCfg); err != nil {
+					return fmt.Errorf("invalid verification of Proof of Possession %w, signer %s", err, bbnAddr.String())
+				}
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().String(btcNetworkFlag, "", "The BTC network to use, one of ['mainnet', 'testnet', 'regtest', 'simnet', 'signet'] (it loads the one set in config if is found)")
 
 	return cmd
 }

--- a/finality-provider/cmd/fpd/daemon/tx.go
+++ b/finality-provider/cmd/fpd/daemon/tx.go
@@ -86,6 +86,10 @@ func NewValidateSignedFinalityProviderCmd() *cobra.Command {
 			}
 
 			msgs := stdTx.GetMsgs()
+			if len(msgs) == 0 {
+				return fmt.Errorf("invalid msg, there is no msg inside %s file", args[0])
+			}
+
 			for i, sdkMsg := range msgs {
 				msgV2 := msgsV2[i]
 				msg, ok := sdkMsg.(*btcstakingtypes.MsgCreateFinalityProvider)
@@ -121,7 +125,8 @@ func NewValidateSignedFinalityProviderCmd() *cobra.Command {
 				}
 			}
 
-			return nil
+			_, err = cmd.OutOrStdout().Write([]byte("The signed msgs are valid"))
+			return err
 		},
 	}
 

--- a/finality-provider/cmd/fpd/daemon/tx_test.go
+++ b/finality-provider/cmd/fpd/daemon/tx_test.go
@@ -100,7 +100,7 @@ func FuzzNewValidateSignedFinalityProviderCmd(f *testing.F) {
 
 		// executes the verification.
 		_, outputValidate := exec(t, root, rootCmdBuff, "tx", "validate-signed-finality-provider", signedMsgFilePath, homeFlag)
-		require.Equal(t, "The signed msgs are valid", outputValidate)
+		require.Equal(t, "The signed MsgCreateFinalityProvider is valid", outputValidate)
 	})
 }
 

--- a/finality-provider/cmd/fpd/daemon/tx_test.go
+++ b/finality-provider/cmd/fpd/daemon/tx_test.go
@@ -2,31 +2,112 @@ package daemon_test
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
+	"math/rand"
+	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/client/keys"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/spf13/cobra"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/babylonchain/babylon/app"
+	"github.com/babylonchain/babylon/testutil/datagen"
+	bbn "github.com/babylonchain/babylon/types"
+
+	btcstakingtypes "github.com/babylonchain/babylon/x/btcstaking/types"
 	fpcmd "github.com/babylonchain/finality-provider/finality-provider/cmd"
 	"github.com/babylonchain/finality-provider/finality-provider/cmd/fpd/daemon"
 	fpcfg "github.com/babylonchain/finality-provider/finality-provider/config"
-	"github.com/cosmos/cosmos-sdk/client"
-	"github.com/cosmos/cosmos-sdk/client/flags"
-	"github.com/spf13/cobra"
-	"github.com/stretchr/testify/require"
+	"github.com/babylonchain/finality-provider/testutil"
 )
 
-func TestNewValidateSignedFinalityProviderCmd(t *testing.T) {
-	root := rootCmd()
-	temp := filepath.Join(t.TempDir(), "homefpnew")
+func FuzzNewValidateSignedFinalityProviderCmd(f *testing.F) {
+	testutil.AddRandomSeedsToFuzzer(f, 10)
+	tempApp := app.NewTmpBabylonApp()
 
-	_, _, err := executeCommandC(root, "init", fmt.Sprintf("--home=%s", temp))
-	require.NoError(t, err)
+	f.Fuzz(func(t *testing.T, seed int64) {
+		r := rand.New(rand.NewSource(seed))
+
+		rootCmdBuff := new(bytes.Buffer)
+		root := rootCmd(rootCmdBuff)
+
+		tDir := t.TempDir()
+		tempHome := filepath.Join(tDir, "homefpnew")
+		homeFlag := fmt.Sprintf("--home=%s", tempHome)
+
+		exec(t, root, rootCmdBuff, "init", homeFlag)
+
+		keyName := datagen.GenRandomHexStr(r, 5)
+		kbt := "--keyring-backend=test"
+
+		keyOut := execUnmarshal[keys.KeyOutput](t, root, rootCmdBuff, "keys", "add", keyName, homeFlag, kbt)
+		require.Equal(t, keyName, keyOut.Name)
+
+		fpAddr, err := sdk.AccAddressFromBech32(keyOut.Address)
+		require.NoError(t, err)
+
+		btcSK, btcPK, err := datagen.GenRandomBTCKeyPair(r)
+		require.NoError(t, err)
+
+		pop, err := btcstakingtypes.NewPoPBTC(fpAddr, btcSK)
+		require.NoError(t, err)
+
+		popHex, err := pop.ToHexStr()
+		require.NoError(t, err)
+
+		bip340PK := bbn.NewBIP340PubKeyFromBTCPK(btcPK)
+
+		_, unsignedMsgStr := exec(
+			t, root, rootCmdBuff, "tx", "create-finality-provider", bip340PK.MarshalHex(), popHex, homeFlag, kbt,
+			fmt.Sprintf("--from=%s", keyName), "--generate-only", "--gas-prices=10ubbn",
+			"--commission-rate=0.05", "--moniker='niceFP'", "--identity=x", "--website=test.com",
+			"--security-contact=niceEmail", "--details='no Details'",
+		)
+
+		tx, err := tempApp.TxConfig().TxJSONDecoder()([]byte(unsignedMsgStr))
+		require.NoError(t, err)
+
+		txMsgs := tx.GetMsgs()
+		require.Len(t, txMsgs, 1)
+		sdkMsg := txMsgs[0]
+
+		msg, ok := sdkMsg.(*btcstakingtypes.MsgCreateFinalityProvider)
+		require.True(t, ok)
+		require.Equal(t, msg.Addr, fpAddr.String())
+
+		// sends the unsigned msg to a file to be signed.
+		unsignedMsgFilePath := writeToTempFile(t, r, unsignedMsgStr)
+
+		_, signedMsgStr := exec(t, root, rootCmdBuff, "tx", "sign", unsignedMsgFilePath, homeFlag, kbt,
+			fmt.Sprintf("--from=%s", keyName), "--offline", "--account-number=0", "--sequence=0",
+		)
+		// sends the signed msg to a file.
+		signedMsgFilePath := writeToTempFile(t, r, signedMsgStr)
+
+		tx, err = tempApp.TxConfig().TxJSONDecoder()([]byte(signedMsgStr))
+		require.NoError(t, err)
+
+		msgSigned := tx.GetMsgs()[0].(*btcstakingtypes.MsgCreateFinalityProvider)
+		require.Equal(t, msgSigned.Addr, fpAddr.String())
+
+		// executes the verification.
+		_, outputValidate := exec(t, root, rootCmdBuff, "tx", "validate-signed-finality-provider", signedMsgFilePath, homeFlag)
+		require.Equal(t, "The signed msgs are valid", outputValidate)
+	})
 }
 
-func rootCmd() *cobra.Command {
+func rootCmd(outputBuff *bytes.Buffer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "fpd",
-		PersistentPreRunE: fpcmd.PersistClientCtx(client.Context{}),
+		PersistentPreRunE: fpcmd.PersistClientCtx(client.Context{}.WithOutput(outputBuff)),
 	}
 	cmd.PersistentFlags().String(flags.FlagHome, fpcfg.DefaultFpdDir, "The application home directory")
 
@@ -40,13 +121,52 @@ func rootCmd() *cobra.Command {
 	return cmd
 }
 
-func executeCommandC(root *cobra.Command, args ...string) (c *cobra.Command, output string, err error) {
+// exec executes a command based on the cmd passed, the args should only search for subcommands, not parent commands
+// it also receives rootCmdBuf as a parameter, which is the buff set in the cmd context standard output for the commands
+// that do print to the context stdout instead of the root stdout.
+func exec(t *testing.T, root *cobra.Command, rootCmdBuf *bytes.Buffer, args ...string) (c *cobra.Command, output string) {
 	buf := new(bytes.Buffer)
 	root.SetOut(buf)
 	root.SetErr(buf)
 	root.SetArgs(args)
 
-	c, err = root.ExecuteC()
+	c, err := root.ExecuteC()
+	require.NoError(t, err)
 
-	return c, buf.String(), err
+	outStr := buf.String()
+	if len(outStr) > 0 {
+		return c, outStr
+	}
+
+	_, err = buf.Write(rootCmdBuf.Bytes())
+	require.NoError(t, err)
+
+	return c, buf.String()
+}
+
+func execUnmarshal[structure any](t *testing.T, root *cobra.Command, rootCmdBuf *bytes.Buffer, args ...string) (output structure) {
+	var typed structure
+	_, outStr := exec(t, root, rootCmdBuf, args...)
+
+	// helpfull for debug
+	// fmt.Printf("\nargs %s", strings.Join(args, " "))
+	// fmt.Printf("\nout %s", outStr)
+
+	err := json.Unmarshal([]byte(outStr), &typed)
+	require.NoError(t, err)
+
+	return typed
+}
+
+func writeToTempFile(t *testing.T, r *rand.Rand, str string) (outputFilePath string) {
+	outputFilePath = filepath.Join(t.TempDir(), datagen.GenRandomHexStr(r, 5))
+
+	outPutFile, err := os.Create(outputFilePath)
+	require.NoError(t, err)
+	defer outPutFile.Close()
+
+	_, err = outPutFile.WriteString(str)
+	require.NoError(t, err)
+
+	return outputFilePath
 }

--- a/finality-provider/cmd/fpd/daemon/tx_test.go
+++ b/finality-provider/cmd/fpd/daemon/tx_test.go
@@ -1,0 +1,52 @@
+package daemon_test
+
+import (
+	"bytes"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	fpcmd "github.com/babylonchain/finality-provider/finality-provider/cmd"
+	"github.com/babylonchain/finality-provider/finality-provider/cmd/fpd/daemon"
+	fpcfg "github.com/babylonchain/finality-provider/finality-provider/config"
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewValidateSignedFinalityProviderCmd(t *testing.T) {
+	root := rootCmd()
+	temp := filepath.Join(t.TempDir(), "homefpnew")
+
+	_, _, err := executeCommandC(root, "init", fmt.Sprintf("--home=%s", temp))
+	require.NoError(t, err)
+}
+
+func rootCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:               "fpd",
+		PersistentPreRunE: fpcmd.PersistClientCtx(client.Context{}),
+	}
+	cmd.PersistentFlags().String(flags.FlagHome, fpcfg.DefaultFpdDir, "The application home directory")
+
+	cmd.AddCommand(
+		daemon.CommandInit(), daemon.CommandStart(), daemon.CommandKeys(),
+		daemon.CommandGetDaemonInfo(), daemon.CommandCreateFP(), daemon.CommandLsFP(),
+		daemon.CommandInfoFP(), daemon.CommandRegisterFP(), daemon.CommandAddFinalitySig(),
+		daemon.CommandExportFP(), daemon.CommandTxs(),
+	)
+
+	return cmd
+}
+
+func executeCommandC(root *cobra.Command, args ...string) (c *cobra.Command, output string, err error) {
+	buf := new(bytes.Buffer)
+	root.SetOut(buf)
+	root.SetErr(buf)
+	root.SetArgs(args)
+
+	c, err = root.ExecuteC()
+
+	return c, buf.String(), err
+}

--- a/finality-provider/config/config.go
+++ b/finality-provider/config/config.go
@@ -184,22 +184,13 @@ func (cfg *Config) Validate() error {
 	// Multiple networks can't be selected simultaneously.  Count number of
 	// network flags passed; assign active network params
 	// while we're at it.
-	switch cfg.BitcoinNetwork {
-	case "mainnet":
-		cfg.BTCNetParams = chaincfg.MainNetParams
-	case "testnet":
-		cfg.BTCNetParams = chaincfg.TestNet3Params
-	case "regtest":
-		cfg.BTCNetParams = chaincfg.RegressionNetParams
-	case "simnet":
-		cfg.BTCNetParams = chaincfg.SimNetParams
-	case "signet":
-		cfg.BTCNetParams = chaincfg.SigNetParams
-	default:
-		return fmt.Errorf("invalid network: %v", cfg.BitcoinNetwork)
+	btcNetConfig, err := NetParamsBTC(cfg.BitcoinNetwork)
+	if err != nil {
+		return err
 	}
+	cfg.BTCNetParams = btcNetConfig
 
-	_, err := net.ResolveTCPAddr("tcp", cfg.RpcListener)
+	_, err = net.ResolveTCPAddr("tcp", cfg.RpcListener)
 	if err != nil {
 		return fmt.Errorf("invalid RPC listener address %s, %w", cfg.RpcListener, err)
 	}
@@ -214,4 +205,22 @@ func (cfg *Config) Validate() error {
 
 	// All good, return the sanitized result.
 	return nil
+}
+
+// NetParamsBTC parses the BTC net params from config.
+func NetParamsBTC(btcNet string) (p chaincfg.Params, err error) {
+	switch btcNet {
+	case "mainnet":
+		return chaincfg.MainNetParams, nil
+	case "testnet":
+		return chaincfg.TestNet3Params, nil
+	case "regtest":
+		return chaincfg.RegressionNetParams, nil
+	case "simnet":
+		return chaincfg.SimNetParams, nil
+	case "signet":
+		return chaincfg.SigNetParams, nil
+	default:
+		return p, fmt.Errorf("invalid network: %v", btcNet)
+	}
 }


### PR DESCRIPTION
Add new command helper to validate signed `MsgCreateFinalityProvider` stored in file

Closes: https://github.com/babylonchain/finality-provider/issues/521