### PR TITLE
chore: migrate from btc-pk to eots-pk in eotsd related commands and docs

### DIFF
--- a/docs/eots.md
+++ b/docs/eots.md
@@ -127,8 +127,8 @@ You can use your key to create a Schnorr signature over arbitrary data
 through the `eotsd sign-schnorr` command.
 The command takes as an argument the file path, hashes the file content using
 sha256, and signs the hash with the EOTS private key in Schnorr format by the
-given `key-name` or `btc-pk`. If both flags `--key-name` and `--btc-pk` are
-provided, `btc-pk` takes priority.
+given `key-name` or `eots-pk`. If both flags `--key-name` and `--eots-pk` are
+provided, `eots-pk` takes priority.
 
 ```shell
 eotsd sign-schnorr /path/to/data/file --home /path/to/eotsd/home/ --key-name my-key-name --keyring-backend file
@@ -146,12 +146,12 @@ You can verify the Schnorr signature signed in the previous step through
 the `eptsd veify-schnorr-sig` command.
 The command takes as an argument the file path, hashes the file content using
 sha256 to generate the signed data, and verifies the signature from the `--signature`
-flag using the given public key from the `--btc-pk` flag.
+flag using the given public key from the `--eots-pk` flag.
 If the signature is valid, you will see `Verification is successful!` in the output.
 Otherwise, an error message will be printed out.
 
 ```shell
-eotsd verify-schnorr-sig /path/to/data/file --btc-pk 50b106208c921b5e8a1c45494306fe1fc2cf68f33b8996420867dc7667fde383 \
+eotsd verify-schnorr-sig /path/to/data/file --eots-pk 50b106208c921b5e8a1c45494306fe1fc2cf68f33b8996420867dc7667fde383 \
 --signature b91fc06b30b78c0ca66a7e033184d89b61cd6ab572329b20f6052411ab83502effb5c9a1173ed69f20f6502a741eeb5105519bb3f67d37612bc2bcce411f8d72 \
 --keyring-backend file
 ```

--- a/eotsmanager/cmd/eotsd/daemon/flags.go
+++ b/eotsmanager/cmd/eotsd/daemon/flags.go
@@ -6,7 +6,7 @@ const (
 	homeFlag        = "home"
 	forceFlag       = "force"
 	rpcListenerFlag = "rpc-listener"
-	fpPkFlag        = "btc-pk"
+	eotsPkFlag      = "eots-pk"
 	signatureFlag   = "signature"
 
 	// flags for keys

--- a/eotsmanager/cmd/eotsd/daemon/pop.go
+++ b/eotsmanager/cmd/eotsd/daemon/pop.go
@@ -20,7 +20,7 @@ func init() {
 }
 
 // PoPExport the data for exporting the PoP.
-// The PubKeyHex is the public key of the finality provider BTC key to load
+// The PubKeyHex is the public key of the finality provider EOTS key to load
 // the private key and sign the AddressSiged.
 type PoPExport struct {
 	PubKeyHex      string `json:"pub_key_hex"`
@@ -33,8 +33,8 @@ var ExportPoPCommand = cli.Command{
 	Usage:     "Exports the Proof of Possession by signing over the finality provider's Babylon address with the EOTS private key.",
 	UsageText: "pop-export [bbn-address]",
 	Description: `Parse the address received as argument, hash it with
-	sha256 and sign based on the EOTS key associated with the key-name or btc-pk flag.
-	If the both flags are supplied, btc-pk takes priority. Use the generated signature
+	sha256 and sign based on the EOTS key associated with the key-name or eots-pk flag.
+	If the both flags are supplied, eots-pk takes priority. Use the generated signature
 	to build a Proof of Possession and export it.`,
 	Flags: []cli.Flag{
 		cli.StringFlag{
@@ -47,7 +47,7 @@ var ExportPoPCommand = cli.Command{
 			Usage: "The name of the key to load private key for signing",
 		},
 		cli.StringFlag{
-			Name:  fpPkFlag,
+			Name:  eotsPkFlag,
 			Usage: "The public key of the finality-provider to load private key for signing",
 		},
 		cli.StringFlag{
@@ -66,7 +66,7 @@ var ExportPoPCommand = cli.Command{
 
 func ExportPoP(ctx *cli.Context) error {
 	keyName := ctx.String(keyNameFlag)
-	fpPkStr := ctx.String(fpPkFlag)
+	fpPkStr := ctx.String(eotsPkFlag)
 	passphrase := ctx.String(passphraseFlag)
 	keyringBackend := ctx.String(keyringBackendFlag)
 
@@ -78,7 +78,7 @@ func ExportPoP(ctx *cli.Context) error {
 	}
 
 	if len(fpPkStr) == 0 && len(keyName) == 0 {
-		return fmt.Errorf("at least one of the flags: %s, %s needs to be informed", keyNameFlag, fpPkFlag)
+		return fmt.Errorf("at least one of the flags: %s, %s needs to be informed", keyNameFlag, eotsPkFlag)
 	}
 
 	homePath, err := getHomeFlag(ctx)

--- a/eotsmanager/cmd/eotsd/daemon/pop_test.go
+++ b/eotsmanager/cmd/eotsd/daemon/pop_test.go
@@ -43,8 +43,8 @@ func FuzzPoPExport(f *testing.F) {
 
 		bbnAddr := datagen.GenRandomAccount().GetAddress()
 
-		btcPkFlag := fmt.Sprintf("--btc-pk=%s", keyOut.PubKeyHex)
-		exportedPoP := appRunPoPExport(r, t, app, []string{bbnAddr.String(), hFlag, btcPkFlag})
+		eotsBtcPkFlag := fmt.Sprintf("--eots-pk=%s", keyOut.PubKeyHex)
+		exportedPoP := appRunPoPExport(r, t, app, []string{bbnAddr.String(), hFlag, eotsBtcPkFlag})
 		pop, err := btcstktypes.NewPoPBTCFromHex(exportedPoP.PoPHex)
 		require.NoError(t, err)
 

--- a/eotsmanager/cmd/eotsd/daemon/sign.go
+++ b/eotsmanager/cmd/eotsd/daemon/sign.go
@@ -28,9 +28,9 @@ var SignSchnorrSig = cli.Command{
 	Name:      "sign-schnorr",
 	Usage:     "Signs a Schnorr signature over arbitrary data with the EOTS private key.",
 	UsageText: "sign-schnorr [file-path]",
-	Description: `Read the file received as argument, hash it with
-	sha256 and sign based on the Schnorr key associated with the key-name or btc-pk flag.
-	If the both flags are supplied, btc-pk takes priority`,
+	Description: fmt.Sprintf(`Read the file received as argument, hash it with
+	sha256 and sign based on the Schnorr key associated with the %s or %s flag.
+	If the both flags are supplied, %s takes priority`, keyNameFlag, eotsPkFlag, eotsPkFlag),
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  homeFlag,
@@ -42,7 +42,7 @@ var SignSchnorrSig = cli.Command{
 			Usage: "The name of the key to load private key for signing",
 		},
 		cli.StringFlag{
-			Name:  fpPkFlag,
+			Name:  eotsPkFlag,
 			Usage: "The public key of the finality-provider to load private key for signing",
 		},
 		cli.StringFlag{
@@ -65,7 +65,7 @@ var VerifySchnorrSig = cli.Command{
 	UsageText: "verify-schnorr-sig [file-path]",
 	Flags: []cli.Flag{
 		cli.StringFlag{
-			Name:     fpPkFlag,
+			Name:     eotsPkFlag,
 			Usage:    "The EOTS public key that will be used to verify the signature",
 			Required: true,
 		},
@@ -79,7 +79,7 @@ var VerifySchnorrSig = cli.Command{
 }
 
 func SignSchnorrVerify(ctx *cli.Context) error {
-	fpPkStr := ctx.String(fpPkFlag)
+	fpPkStr := ctx.String(eotsPkFlag)
 	signatureHex := ctx.String(signatureFlag)
 
 	args := ctx.Args()
@@ -123,7 +123,7 @@ func SignSchnorrVerify(ctx *cli.Context) error {
 
 func SignSchnorr(ctx *cli.Context) error {
 	keyName := ctx.String(keyNameFlag)
-	fpPkStr := ctx.String(fpPkFlag)
+	fpPkStr := ctx.String(eotsPkFlag)
 	passphrase := ctx.String(passphraseFlag)
 	keyringBackend := ctx.String(keyringBackendFlag)
 
@@ -134,7 +134,7 @@ func SignSchnorr(ctx *cli.Context) error {
 	}
 
 	if len(fpPkStr) == 0 && len(keyName) == 0 {
-		return fmt.Errorf("at least one of the flags: %s, %s needs to be informed", keyNameFlag, fpPkFlag)
+		return fmt.Errorf("at least one of the flags: %s, %s needs to be informed", keyNameFlag, eotsPkFlag)
 	}
 
 	homePath, err := getHomeFlag(ctx)

--- a/eotsmanager/cmd/eotsd/daemon/sign_test.go
+++ b/eotsmanager/cmd/eotsd/daemon/sign_test.go
@@ -52,13 +52,13 @@ func FuzzSignAndVerifySchnorrSig(f *testing.F) {
 		fpInfoPath := filepath.Join(tempDir, "fpInfo.json")
 		writeFpInfoToFile(r, t, fpInfoPath, keyOut.PubKeyHex)
 
-		btcPkFlag := fmt.Sprintf("--btc-pk=%s", keyOut.PubKeyHex)
-		dataSignedBtcPk := appRunSignSchnorr(r, t, app, []string{fpInfoPath, hFlag, btcPkFlag})
-		err = app.Run([]string{"eotsd", "verify-schnorr-sig", fpInfoPath, btcPkFlag, fmt.Sprintf("--signature=%s", dataSignedBtcPk.SchnorrSignatureHex)})
+		eotsBtcPkFlag := fmt.Sprintf("--eots-pk=%s", keyOut.PubKeyHex)
+		dataSignedBtcPk := appRunSignSchnorr(r, t, app, []string{fpInfoPath, hFlag, eotsBtcPkFlag})
+		err = app.Run([]string{"eotsd", "verify-schnorr-sig", fpInfoPath, eotsBtcPkFlag, fmt.Sprintf("--signature=%s", dataSignedBtcPk.SchnorrSignatureHex)})
 		require.NoError(t, err)
 
 		dataSignedKeyName := appRunSignSchnorr(r, t, app, []string{fpInfoPath, hFlag, keyNameFlag})
-		err = app.Run([]string{"eotsd", "verify-schnorr-sig", fpInfoPath, btcPkFlag, fmt.Sprintf("--signature=%s", dataSignedKeyName.SchnorrSignatureHex)})
+		err = app.Run([]string{"eotsd", "verify-schnorr-sig", fpInfoPath, eotsBtcPkFlag, fmt.Sprintf("--signature=%s", dataSignedKeyName.SchnorrSignatureHex)})
 		require.NoError(t, err)
 
 		// check if both generated signatures match
@@ -66,13 +66,13 @@ func FuzzSignAndVerifySchnorrSig(f *testing.F) {
 		require.Equal(t, dataSignedBtcPk.SchnorrSignatureHex, dataSignedKeyName.SchnorrSignatureHex)
 		require.Equal(t, dataSignedBtcPk.SignedDataHashHex, dataSignedKeyName.SignedDataHashHex)
 
-		// sign with both keys and btc-pk, should give btc-pk preference
-		dataSignedBoth := appRunSignSchnorr(r, t, app, []string{fpInfoPath, hFlag, btcPkFlag, keyNameFlag})
+		// sign with both keys and eots-pk, should give eots-pk preference
+		dataSignedBoth := appRunSignSchnorr(r, t, app, []string{fpInfoPath, hFlag, eotsBtcPkFlag, keyNameFlag})
 		require.Equal(t, dataSignedBoth, dataSignedKeyName)
 
-		// the keyname can even be from a invalid keyname, since it gives btc-pk preference
+		// the keyname can even be from a invalid keyname, since it gives eots-pk preference
 		badKeyname := "badKeyName"
-		dataSignedBothBadKeyName := appRunSignSchnorr(r, t, app, []string{fpInfoPath, hFlag, btcPkFlag, fmt.Sprintf("--key-name=%s", badKeyname)})
+		dataSignedBothBadKeyName := appRunSignSchnorr(r, t, app, []string{fpInfoPath, hFlag, eotsBtcPkFlag, fmt.Sprintf("--key-name=%s", badKeyname)})
 		require.Equal(t, badKeyname, dataSignedBothBadKeyName.KeyName)
 		require.Equal(t, dataSignedBtcPk.PubKeyHex, dataSignedBothBadKeyName.PubKeyHex)
 		require.Equal(t, dataSignedBtcPk.SchnorrSignatureHex, dataSignedBothBadKeyName.SchnorrSignatureHex)


### PR DESCRIPTION
This only changes the naming in flag and docs, suggested at https://github.com/babylonchain/pm/pull/67#discussion_r1677552147