### PR TITLE
attempt to fix a data race in OP test

### DIFF
--- a/itest/opstackl2/op_test_manager.go
+++ b/itest/opstackl2/op_test_manager.go
@@ -80,6 +80,10 @@ func StartOpL2ConsumerManager(t *testing.T, numOfConsumerFPs uint8) *OpL2Consume
 	// deploy op-finality-gadget contract and start op stack system
 	opL2ConsumerConfig, opSys := startExtSystemsAndCreateConsumerCfg(t, logger, bh)
 
+	// TODO: this is a hack to try to fix a flaky data race
+	// https://github.com/babylonchain/finality-provider/issues/528
+	time.Sleep(5 * time.Second)
+
 	// init SDK client
 	sdkClient := initSdkClient(opSys, opL2ConsumerConfig, t)
 


### PR DESCRIPTION
## Summary

#528 for context

I feel the root cause is we are creating a ethclient for the L2 in `createMultiFps` while it's starting the op system in `startExtSystemsAndCreateConsumerCfg`

but I don't know if this will work so this is just an attempt

## Test Plan
wait for CI