### PR TITLE
test: op e2e verifier daemon itest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,10 @@ test-e2e-wasmd: clean-e2e install-babylond install-wasmd
 test-e2e-op: clean-e2e install-babylond
 	@go test -race -mod=readonly -timeout=25m -v $(PACKAGES_E2E_OP) -count=1 --tags=e2e_op
 
+TEST_NAME ?= .
+test-e2e-op-single: clean-e2e install-babylond
+	@go test -mod=readonly -timeout=25m -v $(PACKAGES_E2E_OP) -count=1 --tags=e2e_op --run ^$(TEST_NAME)$
+
 DEVNET_REPO_URL := https://github.com/babylonchain/op-e2e-devnet
 TARGET_DIR := ./itest/opstackl2/devnet-data
 

--- a/go.mod
+++ b/go.mod
@@ -440,7 +440,7 @@ replace (
 	github.com/babylonchain/babylon => github.com/babylonchain/babylon-private v0.9.0-rc.2.0.20240717044248-3d8f190c9b0c
 	github.com/babylonchain/babylon-finality-gadget => github.com/babylonchain/babylon-finality-gadget v0.1.3-alpha.0.20240717112351-36562c701716
 	github.com/cockroachdb/pebble => github.com/cockroachdb/pebble v0.0.0-20231018212520-f6cde3fc2fa4
-	github.com/ethereum-optimism/optimism => github.com/babylonchain/optimism v1.7.5-0.20240717115935-8fad1ec9aa03
+	github.com/ethereum-optimism/optimism => github.com/babylonchain/optimism v1.7.5-0.20240717131100-fa941f083b02
 	github.com/ethereum/go-ethereum => github.com/ethereum-optimism/op-geth v1.101315.1-rc.5
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7

--- a/go.mod
+++ b/go.mod
@@ -247,7 +247,7 @@ require (
 	github.com/ethereum/c-kzg-4844 v0.4.0 // indirect
 	github.com/fatih/color v1.15.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/fergusstrange/embedded-postgres v1.10.0 // indirect
+	github.com/fergusstrange/embedded-postgres v1.10.0
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/getsentry/sentry-go v0.27.0 // indirect
 	github.com/go-kit/kit v0.12.0 // indirect
@@ -438,7 +438,7 @@ replace (
 	// use cosmos fork of keyring
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.2.0
 	github.com/babylonchain/babylon => github.com/babylonchain/babylon-private v0.9.0-rc.2.0.20240717044248-3d8f190c9b0c
-	github.com/babylonchain/babylon-finality-gadget => github.com/babylonchain/babylon-finality-gadget v0.1.3-alpha.0.20240726034118-1a197c140f14
+	github.com/babylonchain/babylon-finality-gadget => github.com/babylonchain/babylon-finality-gadget v0.1.3-alpha.0.20240726071303-ed98fb9349be
 	github.com/cockroachdb/pebble => github.com/cockroachdb/pebble v0.0.0-20231018212520-f6cde3fc2fa4
 	github.com/ethereum-optimism/optimism => github.com/babylonchain/optimism v1.7.5-0.20240717131100-fa941f083b02
 	github.com/ethereum/go-ethereum => github.com/ethereum-optimism/op-geth v1.101315.1-rc.5

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 require (
 	github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd // indirect
 	github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792 // indirect
+	github.com/jackc/pgx/v5 v5.6.0 // indirect
 )
 
 require (
@@ -195,7 +196,7 @@ require (
 	github.com/aead/siphash v1.0.1 // indirect
 	github.com/andybalholm/brotli v1.1.0 // indirect
 	github.com/aws/aws-sdk-go v1.44.312 // indirect
-	github.com/babylonchain/babylon-finality-gadget v0.1.3-alpha.0.20240716025522-a7f8cd19f44f
+	github.com/babylonchain/babylon-finality-gadget v0.1.3
 	github.com/babylonchain/babylon-sdk/x v0.0.0-20240705194516-4e2c5650cde8 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
@@ -246,7 +247,7 @@ require (
 	github.com/ethereum/c-kzg-4844 v0.4.0 // indirect
 	github.com/fatih/color v1.15.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/fergusstrange/embedded-postgres v1.10.0 // indirect
+	github.com/fergusstrange/embedded-postgres v1.10.0
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/getsentry/sentry-go v0.27.0 // indirect
 	github.com/go-kit/kit v0.12.0 // indirect
@@ -437,6 +438,7 @@ replace (
 	// use cosmos fork of keyring
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.2.0
 	github.com/babylonchain/babylon => github.com/babylonchain/babylon-private v0.9.0-rc.2.0.20240717044248-3d8f190c9b0c
+	github.com/babylonchain/babylon-finality-gadget => github.com/babylonchain/babylon-finality-gadget v0.1.3-alpha.0.20240717112351-36562c701716
 	github.com/cockroachdb/pebble => github.com/cockroachdb/pebble v0.0.0-20231018212520-f6cde3fc2fa4
 	github.com/ethereum-optimism/optimism => github.com/babylonchain/optimism v1.7.5-0.20240717115935-8fad1ec9aa03
 	github.com/ethereum/go-ethereum => github.com/ethereum-optimism/op-geth v1.101315.1-rc.5

--- a/go.mod
+++ b/go.mod
@@ -247,7 +247,7 @@ require (
 	github.com/ethereum/c-kzg-4844 v0.4.0 // indirect
 	github.com/fatih/color v1.15.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/fergusstrange/embedded-postgres v1.10.0
+	github.com/fergusstrange/embedded-postgres v1.10.0 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/getsentry/sentry-go v0.27.0 // indirect
 	github.com/go-kit/kit v0.12.0 // indirect
@@ -438,7 +438,7 @@ replace (
 	// use cosmos fork of keyring
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.2.0
 	github.com/babylonchain/babylon => github.com/babylonchain/babylon-private v0.9.0-rc.2.0.20240717044248-3d8f190c9b0c
-	github.com/babylonchain/babylon-finality-gadget => github.com/babylonchain/babylon-finality-gadget v0.1.3-alpha.0.20240717112351-36562c701716
+	github.com/babylonchain/babylon-finality-gadget => github.com/babylonchain/babylon-finality-gadget v0.1.3-alpha.0.20240726034118-1a197c140f14
 	github.com/cockroachdb/pebble => github.com/cockroachdb/pebble v0.0.0-20231018212520-f6cde3fc2fa4
 	github.com/ethereum-optimism/optimism => github.com/babylonchain/optimism v1.7.5-0.20240717131100-fa941f083b02
 	github.com/ethereum/go-ethereum => github.com/ethereum-optimism/op-geth v1.101315.1-rc.5

--- a/go.sum
+++ b/go.sum
@@ -296,8 +296,8 @@ github.com/aws/aws-sdk-go v1.44.122/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX
 github.com/aws/aws-sdk-go v1.44.312 h1:llrElfzeqG/YOLFFKjg1xNpZCFJ2xraIi3PqSuP+95k=
 github.com/aws/aws-sdk-go v1.44.312/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
-github.com/babylonchain/babylon-finality-gadget v0.1.3-alpha.0.20240726034118-1a197c140f14 h1:WGfybiONeKXAiaUXwBzhRxYIZicqAjHpbXSqOj7xeP0=
-github.com/babylonchain/babylon-finality-gadget v0.1.3-alpha.0.20240726034118-1a197c140f14/go.mod h1:jzTCknX0PH2tczi6FPqGmWftums3uej5y6ZmEDjOIPw=
+github.com/babylonchain/babylon-finality-gadget v0.1.3-alpha.0.20240726071303-ed98fb9349be h1:B70jTqYRiaWbghWN5LP+v4jaROrBo9FCgEqRaH9iSwA=
+github.com/babylonchain/babylon-finality-gadget v0.1.3-alpha.0.20240726071303-ed98fb9349be/go.mod h1:LgEqT5oHGpqRLVMc/qwB9TM99biKYZQDdyrb7Xw6HWI=
 github.com/babylonchain/babylon-private v0.9.0-rc.2.0.20240717044248-3d8f190c9b0c h1:Q8vNr512o6zxxTg1rC41j+s5IS13B1c5kduQmps6pho=
 github.com/babylonchain/babylon-private v0.9.0-rc.2.0.20240717044248-3d8f190c9b0c/go.mod h1:eVovUiLvCvHRpXV7f8KzC4FND1UryaZmZc3bEdBvB8w=
 github.com/babylonchain/babylon-sdk/demo v0.0.0-20240705194516-4e2c5650cde8 h1:VzLjjsynyYaOsIiLwVwMQDXbh1nsQWVpLYLi09R0mh0=

--- a/go.sum
+++ b/go.sum
@@ -304,8 +304,8 @@ github.com/babylonchain/babylon-sdk/demo v0.0.0-20240705194516-4e2c5650cde8 h1:V
 github.com/babylonchain/babylon-sdk/demo v0.0.0-20240705194516-4e2c5650cde8/go.mod h1:X4QovCWMwqMjoTriu18w4gfqX1sYqOWRnZwXGYD8bnE=
 github.com/babylonchain/babylon-sdk/x v0.0.0-20240705194516-4e2c5650cde8 h1:W8jr9BHOLD9RJviI6TmnWPwZpMSjliQNIbNuflBx6vo=
 github.com/babylonchain/babylon-sdk/x v0.0.0-20240705194516-4e2c5650cde8/go.mod h1:Ojrlnwh9z7fvmTUzYH4Tk+8hWSctCrZYWiC5+t4X32I=
-github.com/babylonchain/optimism v1.7.5-0.20240717115935-8fad1ec9aa03 h1:vKQCvOfbZLGQjMynEmlN+zeHkadN0g/8mQ6kYtnypIE=
-github.com/babylonchain/optimism v1.7.5-0.20240717115935-8fad1ec9aa03/go.mod h1:W23NXCxf6fqmYeg3YRvbnBFD9lCqrYyUoRR0mK3WZtg=
+github.com/babylonchain/optimism v1.7.5-0.20240717131100-fa941f083b02 h1:5YRcTxaQmVFhurqavmuhUnF05ygR0fqPCajGljwkL4U=
+github.com/babylonchain/optimism v1.7.5-0.20240717131100-fa941f083b02/go.mod h1:W23NXCxf6fqmYeg3YRvbnBFD9lCqrYyUoRR0mK3WZtg=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.5 h1:VvXlSJBzZpA/zum6Sj74hxwYI2DIxRWuNIoXAzHZz5o=

--- a/go.sum
+++ b/go.sum
@@ -296,8 +296,8 @@ github.com/aws/aws-sdk-go v1.44.122/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX
 github.com/aws/aws-sdk-go v1.44.312 h1:llrElfzeqG/YOLFFKjg1xNpZCFJ2xraIi3PqSuP+95k=
 github.com/aws/aws-sdk-go v1.44.312/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
-github.com/babylonchain/babylon-finality-gadget v0.1.3-alpha.0.20240717112351-36562c701716 h1:APKL8yLL1vs1UciEbq5tCoBBGZLSVc6OZ3nnzxO2uGw=
-github.com/babylonchain/babylon-finality-gadget v0.1.3-alpha.0.20240717112351-36562c701716/go.mod h1:jzTCknX0PH2tczi6FPqGmWftums3uej5y6ZmEDjOIPw=
+github.com/babylonchain/babylon-finality-gadget v0.1.3-alpha.0.20240726034118-1a197c140f14 h1:WGfybiONeKXAiaUXwBzhRxYIZicqAjHpbXSqOj7xeP0=
+github.com/babylonchain/babylon-finality-gadget v0.1.3-alpha.0.20240726034118-1a197c140f14/go.mod h1:jzTCknX0PH2tczi6FPqGmWftums3uej5y6ZmEDjOIPw=
 github.com/babylonchain/babylon-private v0.9.0-rc.2.0.20240717044248-3d8f190c9b0c h1:Q8vNr512o6zxxTg1rC41j+s5IS13B1c5kduQmps6pho=
 github.com/babylonchain/babylon-private v0.9.0-rc.2.0.20240717044248-3d8f190c9b0c/go.mod h1:eVovUiLvCvHRpXV7f8KzC4FND1UryaZmZc3bEdBvB8w=
 github.com/babylonchain/babylon-sdk/demo v0.0.0-20240705194516-4e2c5650cde8 h1:VzLjjsynyYaOsIiLwVwMQDXbh1nsQWVpLYLi09R0mh0=

--- a/go.sum
+++ b/go.sum
@@ -296,8 +296,8 @@ github.com/aws/aws-sdk-go v1.44.122/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX
 github.com/aws/aws-sdk-go v1.44.312 h1:llrElfzeqG/YOLFFKjg1xNpZCFJ2xraIi3PqSuP+95k=
 github.com/aws/aws-sdk-go v1.44.312/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
-github.com/babylonchain/babylon-finality-gadget v0.1.3-alpha.0.20240716025522-a7f8cd19f44f h1:FykJmDmmw5CypzzNBskqDugs9HvIXpJ+vxa0J0jzPlA=
-github.com/babylonchain/babylon-finality-gadget v0.1.3-alpha.0.20240716025522-a7f8cd19f44f/go.mod h1:UkRb1walvNDdEF4fcJVz+M1t7Ok62PkayI40BtxYOGI=
+github.com/babylonchain/babylon-finality-gadget v0.1.3-alpha.0.20240717112351-36562c701716 h1:APKL8yLL1vs1UciEbq5tCoBBGZLSVc6OZ3nnzxO2uGw=
+github.com/babylonchain/babylon-finality-gadget v0.1.3-alpha.0.20240717112351-36562c701716/go.mod h1:jzTCknX0PH2tczi6FPqGmWftums3uej5y6ZmEDjOIPw=
 github.com/babylonchain/babylon-private v0.9.0-rc.2.0.20240717044248-3d8f190c9b0c h1:Q8vNr512o6zxxTg1rC41j+s5IS13B1c5kduQmps6pho=
 github.com/babylonchain/babylon-private v0.9.0-rc.2.0.20240717044248-3d8f190c9b0c/go.mod h1:eVovUiLvCvHRpXV7f8KzC4FND1UryaZmZc3bEdBvB8w=
 github.com/babylonchain/babylon-sdk/demo v0.0.0-20240705194516-4e2c5650cde8 h1:VzLjjsynyYaOsIiLwVwMQDXbh1nsQWVpLYLi09R0mh0=
@@ -1014,10 +1014,15 @@ github.com/jackc/pgx/v4 v4.0.0-pre1.0.20190824185557-6972a5742186/go.mod h1:X+GQ
 github.com/jackc/pgx/v4 v4.12.1-0.20210724153913-640aa07df17c/go.mod h1:1QD0+tgSXP7iUjYm9C1NxKhny7lq6ee99u/z+IHFcgs=
 github.com/jackc/pgx/v4 v4.18.2 h1:xVpYkNR5pk5bMCZGfClbO962UIqVABcAGt7ha1s/FeU=
 github.com/jackc/pgx/v4 v4.18.2/go.mod h1:Ey4Oru5tH5sB6tV7hDmfWFahwF15Eb7DNXlRKx2CkVw=
+github.com/jackc/pgx/v5 v5.6.0 h1:SWJzexBzPL5jb0GEsrPMLIsi/3jOo7RHlzTjcAeDrPY=
+github.com/jackc/pgx/v5 v5.6.0/go.mod h1:DNZ/vlrUnhWCoFGxHAG8U2ljioxukquj7utPDgtQdTw=
 github.com/jackc/puddle v0.0.0-20190413234325-e4ced69a3a2b/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v0.0.0-20190608224051-11cab39313c9/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.3/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
+github.com/jackc/puddle v1.3.0 h1:eHK/5clGOatcjX3oWGBO/MpxpbHzSwud5EWTSCI+MX0=
 github.com/jackc/puddle v1.3.0/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
+github.com/jackc/puddle/v2 v2.2.1 h1:RhxXJtFG022u4ibrCSMSiu5aOq1i77R3OHKNJj77OAk=
+github.com/jackc/puddle/v2 v2.2.1/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/jackpal/go-nat-pmp v1.0.2 h1:KzKSgb7qkJvOUTqYl9/Hg/me3pWgBmERKrTGD7BdWus=
 github.com/jackpal/go-nat-pmp v1.0.2/go.mod h1:QPH045xvCAeXUZOxsnwmrtiCoxIr9eob+4orBN1SBKc=
 github.com/jbenet/go-cienv v0.1.0/go.mod h1:TqNnHUmJgXau0nCzC7kXWeotg3J9W34CUv5Djy1+FlA=


### PR DESCRIPTION
## Summary

This PR adds integration tests for the new verifier daemon in `babylon-finality-gadget`, a stateful program used to track consecutive quorum and query the latest BTC-finalized block.

- feature overview: https://github.com/babylonchain/pm-integration/issues/8
- implementation: https://github.com/babylonchain/babylon-finality-gadget/pull/62

## Test Plan
```
make lint
make test-e2e-op
```